### PR TITLE
Add Load Video node

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -10,16 +10,18 @@ from PIL.PngImagePlugin import PngInfo
 import folder_paths
 from .logger import logger
 
+ffmpeg_path = shutil.which("ffmpeg")
+if ffmpeg_path is None:
+    logger.warning("ffmpeg could not be found. Outputs that require it have been disabled")
+
 class VideoCombine:
     @classmethod
     def INPUT_TYPES(s):
-        ffmpeg_path = shutil.which("ffmpeg")
         #Hide ffmpeg formats if ffmpeg isn't available
         if ffmpeg_path is not None:
             ffmpeg_formats = ["video/"+x[:-5] for x in folder_paths.get_filename_list("video_formats")]
         else:
             ffmpeg_formats = []
-            logger.warning("ffmpeg could not be found. Outputs that require it have been disabled")
         return {
             "required": {
                 "images": ("IMAGE",),

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -266,7 +266,7 @@ class LoadVideo:
                 current_bytes[current_offset:len(bytes_read)] = bytes_read
                 current_offset+=len(bytes_read)
                 if current_offset == bpi:
-                    images.append(np.array(current_bytes, dtype=np.float32).reshape(size[0], size[1], 3) / 255.0)
+                    images.append(np.array(current_bytes, dtype=np.float32).reshape(size[1], size[0], 3) / 255.0)
                     current_offset = 0
             if current_offset != 0:
                 logger.warn(f'{current_offset} bytes left over when loading image')

--- a/web/js/gif_preview.js
+++ b/web/js/gif_preview.js
@@ -102,7 +102,7 @@ const gif_preview = {
             case 'VHS_VideoCombine':{
                 const onExecuted = nodeType.prototype.onExecuted
                 nodeType.prototype.onExecuted = function (message) {
-                const prefix = 'ad_gif_preview_'
+                const prefix = 'vhs_gif_preview_'
                 const r = onExecuted ? onExecuted.apply(this, message) : undefined
 
                 if (this.widgets) {


### PR DESCRIPTION
I'm opening this pull request early as an indicator of what I'm working on currently.

The python code for interfacing with ffmpeg to load a video as a series of frames is functional, but I'm planning to do a good bit of refactoring on the javascript side in order to
- Allow uploading of videos from the webui
- Generalize the video preview code to also work for the new Load Video node
- Implement the requested functionality for pausing/hiding video previews
- (hopefully,)  display a still image preview in the format designated in webui settings when the video preview is set to paused.