### PR TITLE
CV LoadVideo + other small things

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+opencv-python

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -274,11 +274,11 @@ class LoadVideo:
                     if not is_returned:
                         break
                     time_offset += base_frame_time
-                    total_frame_count += 1
                 if time_offset < target_frame_time:
                     continue
                 time_offset -= target_frame_time
                 # if not at start_index, skip doing anything with frame
+                total_frame_count += 1
                 if total_frame_count <= skip_first_frames:
                     continue
                 # TODO: do whatever operations need to happen, like force_size, etc
@@ -330,10 +330,10 @@ class LoadVideo:
                              "-pix_fmt", "rgb24"]
 
         vfilters = []
-        if skip_first_frames > 0:
-            vfilters.append(f"select=gt(n\\,{skip_first_frames})")
         if force_rate != 0:
             vfilters.append("fps="+str(force_rate))
+        if skip_first_frames > 0:
+            vfilters.append(f"select=gt(n\\,{skip_first_frames-1})")
         if frame_load_cap > 0:
             vfilters.append(f"select=gt({frame_load_cap}\\,n)")
         #manually calculate aspect ratio to ensure reads remain aligned

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -1,4 +1,5 @@
 import os
+import hashlib
 import json
 import subprocess
 import shutil
@@ -7,8 +8,9 @@ import time
 import numpy as np
 from typing import List
 import torch
-from PIL import Image
+from PIL import Image, ImageOps
 from PIL.PngImagePlugin import PngInfo
+import cv2
 
 import folder_paths
 from .logger import logger
@@ -16,6 +18,7 @@ from .logger import logger
 ffmpeg_path = shutil.which("ffmpeg")
 if ffmpeg_path is None:
     logger.warning("ffmpeg could not be found. Outputs that require it have been disabled")
+
 
 class VideoCombine:
     @classmethod
@@ -30,7 +33,7 @@ class VideoCombine:
                 "images": ("IMAGE",),
                 "frame_rate": (
                     "INT",
-                    {"default": 8, "min": 1, "max": 24, "step": 1},
+                    {"default": 8, "min": 1, "step": 1},
                 ),
                 "loop_count": ("INT", {"default": 0, "min": 0, "max": 100, "step": 1}),
                 "filename_prefix": ("STRING", {"default": "AnimateDiff"}),
@@ -46,7 +49,7 @@ class VideoCombine:
 
     RETURN_TYPES = ("GIF",)
     OUTPUT_NODE = True
-    CATEGORY = "Video Helper Suite"
+    CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
     FUNCTION = "combine_video"
 
     def save_with_tempfile(self, args, metadata, file_path, frames, env):
@@ -204,7 +207,7 @@ class VideoCombine:
 class LoadVideo:
     @classmethod
     def INPUT_TYPES(s):
-        video_extensions = ['webm', 'mp4', 'mkv']
+        video_extensions = ['webm', 'mp4', 'mkv', 'gif']
         input_dir = folder_paths.get_input_directory()
         files = []
         for f in os.listdir(input_dir):
@@ -212,19 +215,70 @@ class LoadVideo:
                 file_parts = f.split('.')
                 if len(file_parts) > 1 and (file_parts[-1] in video_extensions):
                     files.append(f)
-        return {"required":
-                    {"video": (sorted(files), {"video_upload": True}),
-                     "force_rate": ("INT", {"default": 0, "min": 0, "max": 24, "step": 1}),
+        return {"required": {
+                    "video": (sorted(files), {"video_upload": True}),
+                     #"force_rate": ("INT", {"default": 0, "min": 0, "max": 24, "step": 1}),
                      "force_size": (["Disabled", "256x?", "?x256", "256x256", "512x?", "?x512", "512x512"],),
+                     "frame_load_cap": ("INT", {"default": 0, "min": 0, "step": 1}),
+                     "skip_first_frames": ("INT", {"default": 0, "min": 0, "step": 1}),
                      #Consider adding start_frame/total_frames here?
                      #Might be a bit finicky since ffmpeg usually works in time/duration, not frame numbers
                      },}
 
-    CATEGORY = "Video Helper Suite"
+    CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
 
-    RETURN_TYPES = ("IMAGE",)
-    FUNCTION = "load_video"
-    def load_video(self, video, force_rate, force_size):
+    RETURN_TYPES = ("IMAGE", "INT",)
+    RETURN_NAMES = ("IMAGE", "frame_count",)
+    FUNCTION = "load_video_cv_fallback"
+
+    def is_gif(self, filename):
+        file_parts = filename.split('.')
+        return len(file_parts) > 1 and file_parts[-1] == "gif"
+
+    def load_video_cv_fallback(self, video, force_size, frame_load_cap, skip_first_frames):
+        try:
+            video_cap = cv2.VideoCapture(folder_paths.get_annotated_filepath(video))
+            if not video_cap.isOpened():
+                raise ValueError(f"{video} could not be loaded with cv fallback.")
+            # set video_cap to look at start_index frame
+            images = []
+            total_frame_count = 0
+            frames_added = 0
+            while video_cap.isOpened():
+                # if cap exists and we've reached it, stop processing frames
+                if frame_load_cap > 0 and frames_added >= frame_load_cap:
+                    break
+                is_returned, frame = video_cap.read()
+                # if didn't return frame, video has ended
+                if not is_returned:
+                    break 
+                # if not at start_index, skip doing anything with frame
+                total_frame_count += 1
+                if total_frame_count <= skip_first_frames:
+                    continue
+                # TODO: do whatever operations need to happen, like force_size, etc
+
+                # opencv loads images in BGR format (yuck), so need to convert to RGB for ComfyUI use
+                # follow up: can videos ever have an alpha channel?
+                frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                # convert frame to comfyui's expected format (taken from comfy's load image code)
+                image = Image.fromarray(frame)
+                image = ImageOps.exif_transpose(image)
+                image = np.array(image, dtype=np.float) / 255.0
+                image = torch.from_numpy(image)[None,]
+                images.append(image)
+                frames_added += 1
+        finally:
+            video_cap.release()
+        # TODO: raise an error maybe if no frames were loaded?
+        return (torch.cat(images, dim=0), frames_added)
+
+    def load_video(self, video, force_rate, force_size, frame_load_cap, skip_first_frames):
+        # check if video is a gif - will need to use cv fallback to read frames
+        # use cv fallback if ffmpeg not installed or gif
+        if ffmpeg_path is None or self.is_gif(video):
+            return self.load_video_cv_fallback(video, force_size, frame_load_cap, skip_first_frames)
+        # otherwise, continue with ffmpeg
         video_path = folder_paths.get_annotated_filepath(video)
         args_dummy = ["ffmpeg", "-i", video_path, "-f", "null", "-"]
         with subprocess.Popen(args_dummy, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE) as proc:
@@ -275,18 +329,18 @@ class LoadVideo:
                 logger.warn(f'{current_offset} bytes left over when loading image')
 
         images = torch.from_numpy(np.stack(images))
-        return (images,)
+        return (images, images.size(0))
 
     @classmethod
-    def IS_CHANGED(s, image):
-        image_path = folder_paths.get_annotated_filepath(image)
+    def IS_CHANGED(s, video, force_size, frame_load_cap, skip_first_frames):
+        image_path = folder_paths.get_annotated_filepath(video)
         m = hashlib.sha256()
         with open(image_path, 'rb') as f:
             m.update(f.read())
         return m.digest().hex()
 
     @classmethod
-    def VALIDATE_INPUTS(s, video, force_rate, force_size):
+    def VALIDATE_INPUTS(s, video, force_size, frame_load_cap, skip_first_frames):
         if not folder_paths.exists_annotated_filepath(video):
             return "Invalid image file: {}".format(video)
 
@@ -297,6 +351,6 @@ NODE_CLASS_MAPPINGS = {
     "VHS_LoadVideo": LoadVideo,
 }
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "VHS_VideoCombine": "Video Combine",
-    "VHS_LoadVideo": "Load Video",
+    "VHS_VideoCombine": "Video Combine 🎥🅥🅗🅢",
+    "VHS_LoadVideo": "Load Video 🎥🅥🅗🅢",
 }

--- a/web/js/videoupload.js
+++ b/web/js/videoupload.js
@@ -1,0 +1,100 @@
+import { app } from "../../../scripts/app.js";
+import { api } from '../../../scripts/api.js'
+import { ComfyWidgets } from "../../../scripts/widgets.js"
+
+function videoUpload(node, inputName, inputData, app) {
+    const imageWidget = node.widgets.find((w) => w.name === "video");
+    let uploadWidget;
+
+    var default_value = imageWidget.value;
+    Object.defineProperty(imageWidget, "value", {
+        set : function(value) {
+            this._real_value = value;
+        },
+
+        get : function() {
+            let value = "";
+            if (this._real_value) {
+                value = this._real_value;
+            } else {
+                return default_value;
+            }
+
+            if (value.filename) {
+                let real_value = value;
+                value = "";
+                if (real_value.subfolder) {
+                    value = real_value.subfolder + "/";
+                }
+
+                value += real_value.filename;
+
+                if(real_value.type && real_value.type !== "input")
+                    value += ` [${real_value.type}]`;
+            }
+            return value;
+        }
+    });
+    async function uploadFile(file, updateNode, pasted = false) {
+        try {
+            // Wrap file in formdata so it includes filename
+            const body = new FormData();
+            body.append("image", file);
+            if (pasted) body.append("subfolder", "pasted");
+            const resp = await api.fetchApi("/upload/image", {
+                method: "POST",
+                body,
+            });
+
+            if (resp.status === 200) {
+                const data = await resp.json();
+                // Add the file to the dropdown list and update the widget value
+                let path = data.name;
+                if (data.subfolder) path = data.subfolder + "/" + path;
+
+                if (!imageWidget.options.values.includes(path)) {
+                    imageWidget.options.values.push(path);
+                }
+
+                if (updateNode) {
+                    imageWidget.value = path;
+                }
+            } else {
+                alert(resp.status + " - " + resp.statusText);
+            }
+        } catch (error) {
+            alert(error);
+        }
+    }
+
+    const fileInput = document.createElement("input");
+    Object.assign(fileInput, {
+        type: "file",
+        accept: "video/webm,video/mp4,video/mkv,image/gif",
+        style: "display: none",
+        onchange: async () => {
+            if (fileInput.files.length) {
+                await uploadFile(fileInput.files[0], true);
+            }
+        },
+    });
+    document.body.append(fileInput);
+
+    // Create the button widget for selecting the files
+    uploadWidget = node.addWidget("button", "choose file to upload", "video", () => {
+        fileInput.click();
+    });
+    uploadWidget.serialize = false;
+    return { widget: uploadWidget };
+}
+ComfyWidgets.VIDEOUPLOAD = videoUpload;
+
+app.registerExtension({
+	name: "VideoHelperSuit.UploadVideo",
+	async beforeRegisterNodeDef(nodeType, nodeData, app) {
+		if (nodeData?.name == "VHS_LoadVideo") {
+            console.log("test")
+			nodeData.input.required.upload = ["VIDEOUPLOAD"];
+		}
+	},
+});


### PR DESCRIPTION
Changed LoadVideo node to use cv to support frame_load_cap and skip_first_frames + additional formats, added frame_count output, changed visual appearance of nodes to make it clear what custom nodes they are part of.

If some things in ffmpeg are harder to figure out at the moment, we might go ahead and make Load Video node use opencv for all its functionality. I made it support loading only a certain amount of frames and skipping a certain amount of frames. I also output a frame_count so that it can be passed to nodes that will care about the number of images loaded.

Force_size currently does nothing in this code. If we want to make that work later, we could remove it as a parameter for now and add it back at a later date. I kind of want to start adding the image/latent nodes and then reference this repo in AnimateDiff, so getting this bare amount of functionality will be enough to get peeps going, I think. I want to know what you think about going this route.