### PR TITLE
added initial scaffolding for SaveImageSequence node

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -390,6 +390,30 @@ class LoadVideo:
         return True
 
 
+class SaveImageSequence:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "images": ("IMAGE",),
+            }
+        }
+    
+    CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("directory",)
+    FUNCTION = "save_images"
+    
+    def save_images(self, images: torch.Tensor):
+        # goal: save image sequence,
+        # allowing user to choose padding amount and starting fraame number
+        # as well as subdirectory in output to save it as.
+        # Output directory should have option to either be a set name, or be dynamically
+        # generated with timestamp.
+        pass
+
+
 class LoadImagesFromDirectory:
     @classmethod
     def INPUT_TYPES(s):


### PR DESCRIPTION
Hey, some of the remaining big features I think we need to support are:
1) Saving image sequences in a subdirectory, with the option to use a formatted timestamp as the folder name, and allowing some customization for the saved image sequence (starting number, zero padding amount, etc).
2) Allow saving videos in Combine Video node to also be put in a subdirectory.
3) A node to copy a directory from output into input folder, so that workflows could seamlessly save and then load image sequences.

I want to spend tomorrow looking into some fixes/improvements to Advanced-ControlNet and AnimateDiff, so if you'd have the time to look into this, that would be amazing!

Fizz worked on an initial version of the node for AnimateDiff repo, so that might be a good place to look for the formatted timestamp impl: https://github.com/Kosinkadink/ComfyUI-AnimateDiff-Evolved/pull/11