### PR TITLE
Loadvideo: Fix skip_first_frames, Frame rounding, Improved errors

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -36,6 +36,9 @@ if ffmpeg_path is None:
     except:
         logger.warning("ffmpeg could not be found. Outputs that require it have been disabled")
 
+preferred_backend = "opencv"
+if "VHS_PREFERRED_BACKEND" in os.environ:
+    preferred_backend = os.environ['VHS_PREFERRED_BACKEND']
 
 class VideoCombine:
     @classmethod
@@ -237,8 +240,6 @@ class LoadVideo:
                      "force_size": (["Disabled", "256x?", "?x256", "256x256", "512x?", "?x512", "512x512"],),
                      "frame_load_cap": ("INT", {"default": 0, "min": 0, "step": 1}),
                      "skip_first_frames": ("INT", {"default": 0, "min": 0, "step": 1}),
-                     #Consider adding start_frame/total_frames here?
-                     #Might be a bit finicky since ffmpeg usually works in time/duration, not frame numbers
                      },}
 
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
@@ -266,11 +267,28 @@ class LoadVideo:
                 width = int(force_size[0])
         return (width, height)
 
-    def load_video_cv_fallback(self, video, force_rate, force_size, frame_load_cap, skip_first_frames):
+    known_exceptions = []
+    def load_video(self, **kwargs):
+        backends = [self.load_video_cv, self.load_video_ffmpeg]
+        if preferred_backend == 'ffmpeg':
+            backends.reverse()
+        for backend in backends:
+            try:
+                return backend(**kwargs)
+            except Exception as e:
+                latest_error = e
+                if e.__str__() not in self.known_exceptions:
+                    self.known_exceptions.append(e.__str__())
+                    logger.warn(f"Load with {backend.__name__} failed due to: {e}")
+        error_string = f"Failed to load video: {kwargs['video']}\ndue to: {latest_error.__str__()}"
+        raise RuntimeError(error_string)
+
+
+    def load_video_cv(self, video, force_rate, force_size, frame_load_cap, skip_first_frames):
         try:
             video_cap = cv2.VideoCapture(folder_paths.get_annotated_filepath(video))
             if not video_cap.isOpened():
-                raise ValueError(f"{video} could not be loaded with cv fallback.")
+                raise ValueError(f"{video} could not be loaded with cv.")
             # set video_cap to look at start_index frame
             images = []
             total_frame_count = 0
@@ -314,6 +332,8 @@ class LoadVideo:
                     break
         finally:
             video_cap.release()
+        if len(images) == 0:
+            raise RuntimeError("No frames generated")
         images = torch.cat(images, dim=0)
         if force_size != "Disabled":
             new_size = self.target_size(width, height, force_size)
@@ -324,26 +344,20 @@ class LoadVideo:
         # TODO: raise an error maybe if no frames were loaded?
         return (images, frames_added)
 
-    def load_video(self, video, force_rate, force_size, frame_load_cap, skip_first_frames):
-        # check if video is a gif - will need to use cv fallback to read frames
-        # use cv fallback if ffmpeg not installed or gif
+    def load_video_ffmpeg(self, video, force_rate, force_size, frame_load_cap, skip_first_frames):
         if ffmpeg_path is None:
             return self.load_video_cv_fallback(video, force_rate, force_size, frame_load_cap, skip_first_frames)
         # otherwise, continue with ffmpeg
         video_path = folder_paths.get_annotated_filepath(video)
         args_dummy = [ffmpeg_path, "-i", video_path, "-f", "null", "-"]
-        try:
-            with subprocess.Popen(args_dummy, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE) as proc:
-                for line in proc.stderr.readlines():
-                    match = re.search(", ([1-9]|\\d{2,})x(\\d+)",line.decode('utf-8'))
-                    if match is not None:
-                        size = [int(match.group(1)), int(match.group(2))]
-                        break
-        except Exception as e:
-            logger.info(f"Retrying with opencv due to ffmpeg error: {e}")
-            return self.load_video_cv_fallback(video, force_rate, force_size, frame_load_cap, skip_first_frames)
+        with subprocess.Popen(args_dummy, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE) as proc:
+            for line in proc.stderr.readlines():
+                match = re.search(", ([1-9]|\\d{2,})x(\\d+)",line.decode('utf-8'))
+                if match is not None:
+                    size = [int(match.group(1)), int(match.group(2))]
+                    break
         args_all_frames = [ffmpeg_path, "-an", "-i", video_path, "-v", "error",
-                             "-pix_fmt", "rgb24", "-fps_mode", "vfr"]
+                             "-pix_fmt", "rgb24", "-fps_mode", "drop"]
 
         vfilters = []
         if force_rate != 0:
@@ -360,28 +374,26 @@ class LoadVideo:
 
         args_all_frames += ["-f", "rawvideo", "-"]
         images = []
-        try:
-            with subprocess.Popen(args_all_frames, stdout=subprocess.PIPE) as proc:
-                #Manually buffer enough bytes for an image
-                bpi = size[0]*size[1]*3
-                current_bytes = bytearray(bpi)
-                current_offset=0
-                while True:
-                    bytes_read = proc.stdout.read(bpi - current_offset)
-                    if bytes_read is None:#sleep to wait for more data
-                        time.sleep(.2)
-                        continue
-                    if len(bytes_read) == 0:#EOF
-                        break
-                    current_bytes[current_offset:len(bytes_read)] = bytes_read
-                    current_offset+=len(bytes_read)
-                    if current_offset == bpi:
-                        images.append(np.array(current_bytes, dtype=np.float32).reshape(size[1], size[0], 3) / 255.0)
-                        current_offset = 0
-        except Exception as e:
-            logger.info(f"Retrying with opencv due to ffmpeg error: {e}")
-            return self.load_video_cv_fallback(video, force_rate, force_size, frame_load_cap, skip_first_frames)
+        with subprocess.Popen(args_all_frames, stdout=subprocess.PIPE) as proc:
+            #Manually buffer enough bytes for an image
+            bpi = size[0]*size[1]*3
+            current_bytes = bytearray(bpi)
+            current_offset=0
+            while True:
+                bytes_read = proc.stdout.read(bpi - current_offset)
+                if bytes_read is None:#sleep to wait for more data
+                    time.sleep(.2)
+                    continue
+                if len(bytes_read) == 0:#EOF
+                    break
+                current_bytes[current_offset:len(bytes_read)] = bytes_read
+                current_offset+=len(bytes_read)
+                if current_offset == bpi:
+                    images.append(np.array(current_bytes, dtype=np.float32).reshape(size[1], size[0], 3) / 255.0)
+                    current_offset = 0
 
+        if len(images) == 0:
+            raise RuntimeError("No frames generated")
         images = torch.from_numpy(np.stack(images))
         return (images, images.size(0))
 

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -357,7 +357,7 @@ class LoadVideo:
                     size = [int(match.group(1)), int(match.group(2))]
                     break
         args_all_frames = [ffmpeg_path, "-an", "-i", video_path, "-v", "error",
-                             "-pix_fmt", "rgb24", "-fps_mode", "drop"]
+                             "-pix_fmt", "rgb24", "-vsync", "2"]
 
         vfilters = []
         if force_rate != 0:


### PR DESCRIPTION
Fix #11 by using `-frames:v` instead of `select`

Improve the selection process for which of multiple frames is chosen when a lower framerate is forced. 
Previously, ffmpeg took the center-most frame, and opencv took the last possible frame. 
Now, both take the first valid frame.

The backend selection process and routing has been improved. The default is now opencv, but this can be overridden with the VHS_PREFERRED_BACKEND environment variable. Regardless of which is chosen first, the other is attempted if any error occurs.

Error messages have been improved. A more descriptive error is given when no images were obtained instead of the numpy stack/cat failing and when another backend is used as a fallback, duplicate error messages from the primary backed are suppressed.