### PR TITLE
UploadVideo, gif preview autoplay fix, VideoInfo out from LoadVideo, …

### DIFF
--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -1,7 +1,8 @@
 import os
 import numpy as np
 import torch
-from PIL import Image, ImageOps
+from PIL import Image, ImageOps, ImageSequence
+import re
 import cv2
 
 import folder_paths
@@ -9,16 +10,137 @@ from comfy.utils import common_upscale
 from .logger import logger
 from .utils import calculate_file_hash, get_sorted_dir_files_from_directory
 
+ACCEPTED_VIDEO_EXTENSIONS = ['webm', 'mp4', 'mkv']
+ACCEPTED_IMAGE_EXTENSIONS = ['gif', 'webp', 'apng', 'mjpeg']
 
-video_extensions = ['webm', 'mp4', 'mkv', 'gif']
 
+class VideoInfo:
+    
+    def __init__(self):
+        self.input_frame_count = 0
+        self.input_fps = 0.0
+        self.input_video_duration = 0.0
+        self.input_frame_time = 0.0
+        
+        self.effective_frame_count = 0
+        self.effective_fps = 0.0
+        self.effective_video_duration = 0.0
+        self.effective_frame_time = 0.0
+        
+    @staticmethod
+    def build_video_info(input_fps, input_frame_count, desired_frame_rate, frames_added):
+        
+        video_info = VideoInfo()
+        
+        video_info.input_fps = input_fps
+        video_info.input_frame_count = input_frame_count
+        video_info.input_video_duration = input_frame_count / input_fps
+        video_info.input_frame_time = 1 / input_fps
+        
+        effective_fps = desired_frame_rate if desired_frame_rate > 0.001 else input_fps
+        video_info.effective_fps = effective_fps
+        video_info.effective_frame_count = frames_added
+        video_info.effective_video_duration = frames_added / effective_fps
+        video_info.effective_frame_time = 1 / effective_fps
+        
+        return video_info
 
-def is_gif(filename) -> bool:
+    
+def get_extension(filename):
     file_parts = filename.split('.')
-    return len(file_parts) > 1 and file_parts[-1] == "gif"
+    return len(file_parts) > 1 and file_parts[-1]
+
+def is_webp(filename):
+     return get_extension(filename) == "webp"
+
+def is_gif(filename):
+    return get_extension(filename) == "gif"
+
+def is_video(filename):
+    return get_extension(filename) in ACCEPTED_VIDEO_EXTENSIONS
 
 
-def target_size(width, height, force_size) -> tuple[int, int]:
+class OutVideoInfo:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "in_video_info": ("VHS_VIDEO_INFO",),
+            },
+        }
+
+    CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
+
+    RETURN_TYPES = (
+        "INT", "FLOAT", 
+        "FLOAT", "FLOAT", 
+        
+        "INT", "FLOAT", 
+        "FLOAT", "FLOAT",
+    )
+    
+    RETURN_NAMES = (
+        "input_frame_count", "input_fps", 
+        "input_video_duration", "input_frame_time", 
+        
+        "effective_frame_count", "effective_fps", 
+        "effective_video_duration", "effective_frame_time", 
+    )
+    
+    FUNCTION = "output_video_info"
+
+    def output_video_info(self, in_video_info : VideoInfo):
+        out = (
+            in_video_info.input_frame_count, in_video_info.input_fps, 
+            in_video_info.input_video_duration, in_video_info.input_frame_time,
+            
+            in_video_info.effective_frame_count, in_video_info.effective_fps, 
+            in_video_info.effective_video_duration, in_video_info.effective_frame_time
+        )
+        print(out)
+        return out
+
+
+class LoadVideo:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "video": ("STRING", {"default": "X://insert/path/here.mp4"}),
+                "desired_frame_rate": ("FLOAT", {"default": 0, "min": 0, "step": 1}),
+                "force_size": (["Disabled", "256x?", "?x256", "256x256", "512x?", "?x512", "512x512"],),
+                "frame_load_cap": ("INT", {"default": 0, "min": 0, "step": 1}),
+                "skip_first_frames": ("INT", {"default": 0, "min": 0, "step": 1}),
+                "select_every_nth": ("INT", {"default": 1, "min": 1, "step": 1}),
+            },
+        }
+
+    CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
+
+    RETURN_TYPES = ("IMAGE", "VHS_VIDEO_INFO",)
+    RETURN_NAMES = ("IMAGE", "video_info",)
+    FUNCTION = "load_video"
+    
+    known_exceptions = []
+    def load_video(self, **kwargs):
+        try:
+            return LoadVideo.load_video_cv(**kwargs)
+        except Exception as e:
+            raise RuntimeError(f"Failed to load video: {kwargs['video']}\ndue to: {e.__str__()}")
+
+    @classmethod
+    def IS_CHANGED(s, video, **kwargs):
+        if video is None: # If "video" is a pin
+            return ''
+        return calculate_file_hash(video.strip("\""))
+
+    @classmethod
+    def VALIDATE_INPUTS(s, video, **kwargs):
+        if video is not None and not os.path.isfile(video.strip("\"")):
+            return "Invalid video file: {}".format(video)
+        return True
+    
+    def target_size(width, height, force_size) -> tuple[int, int]:
         if force_size != "Disabled":
             force_size = force_size.split("x")
             if force_size[0] == "?":
@@ -32,153 +154,203 @@ def target_size(width, height, force_size) -> tuple[int, int]:
                 height = int(height)+4 & ~7
                 width = int(force_size[0])
         return (width, height)
-
-
-
-def load_video_cv(video: str, force_rate: int, force_size: str, frame_load_cap: int, skip_first_frames: int, select_every_nth: int):
-    try:
-        video_cap = cv2.VideoCapture(folder_paths.get_annotated_filepath(video.strip("\"")))
-        if not video_cap.isOpened():
-            raise ValueError(f"{video} could not be loaded with cv.")
-        # set video_cap to look at start_index frame
+    
+    def force_size(force_size, width, height, images):
+        if force_size != "Disabled":
+            new_size = LoadVideo.target_size(width, height, force_size)
+            if new_size[0] != width or new_size[1] != height:
+                s = images.movedim(-1,1)
+                s = common_upscale(s, new_size[0], new_size[1], "lanczos", "disabled")
+                return s.movedim(1,-1)
+                
+        return images
+    
+    def load_video_pil(
+            video: str, desired_frame_rate: float, force_size: str, frame_load_cap: int, skip_first_frames: int, select_every_nth: int):
+        """
+        For any other animated type, such as webp, apng, or mjpeg.
+        Can't really use the force_rate param since we're not sampling the video, 
+        we're just loading the frames directly.
+        """
+        
+        logger.info(
+            'Falling back to load_video_pil. desired_frame_rate will be ignored, and the original frame rate will be used. ' +
+            'If desired_frame_rate is important, please consider converting this media to another file type.')
+    
+        try:
+            loaded_video = Image.open(video)
+        except Exception as e:
+            raise Exception(f"Unable to open video with pil fallback: {video}")
+        
+        frames = ImageSequence.Iterator(loaded_video)
+        
         images = []
-        total_frame_count = 0
-        total_frames_evaluated = -1
-        frames_added = 0
-        base_frame_time = 1/video_cap.get(cv2.CAP_PROP_FPS)
-        width = video_cap.get(cv2.CAP_PROP_FRAME_WIDTH)
-        height = video_cap.get(cv2.CAP_PROP_FRAME_HEIGHT)
-        if force_rate == 0:
-            target_frame_time = base_frame_time
-        else:
-            target_frame_time = 1/force_rate
-        time_offset=target_frame_time - base_frame_time
-        while video_cap.isOpened():
-            if time_offset < target_frame_time:
-                is_returned, frame = video_cap.read()
-                # if didn't return frame, video has ended
-                if not is_returned:
-                    break
-                time_offset += base_frame_time
-            if time_offset < target_frame_time:
-                continue
-            time_offset -= target_frame_time
-            # if not at start_index, skip doing anything with frame
-            total_frame_count += 1
-            if total_frame_count <= skip_first_frames:
-                continue
-            else:
-                total_frames_evaluated += 1
-
-            # if should not be selected, skip doing anything with frame
-            if total_frames_evaluated%select_every_nth != 0:
-                continue
-
-            # opencv loads images in BGR format (yuck), so need to convert to RGB for ComfyUI use
-            # follow up: can videos ever have an alpha channel?
-            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-            # convert frame to comfyui's expected format (taken from comfy's load image code)
-            image = Image.fromarray(frame)
-            image = ImageOps.exif_transpose(image)
+        input_frame_time = None
+        for image in frames:
+            if input_frame_time is None:
+                if 'duration' not in image.info:
+                    image.load()
+                input_frame_time = image.info.get('duration', None)
             image = np.array(image, dtype=np.float32) / 255.0
             image = torch.from_numpy(image)[None,]
             images.append(image)
-            frames_added += 1
-            # if cap exists and we've reached it, stop processing frames
-            if frame_load_cap > 0 and frames_added >= frame_load_cap:
-                break
-    finally:
-        video_cap.release()
-    if len(images) == 0:
-        raise RuntimeError("No frames generated")
-    images = torch.cat(images, dim=0)
-    if force_size != "Disabled":
-        new_size = target_size(width, height, force_size)
-        if new_size[0] != width or new_size[1] != height:
-            s = images.movedim(-1,1)
-            s = common_upscale(s, new_size[0], new_size[1], "lanczos", "disabled")
-            images = s.movedim(1,-1)
-    # TODO: raise an error maybe if no frames were loaded?
-    return (images, frames_added)
+            
+        if input_frame_time is None:
+            raise Exception(f"Could not get input_frame_time from video: {video}")
+            
+        input_frame_count = len(images)
+            
+        input_fps = 1000 / input_frame_time
+        width = loaded_video.width
+        height = loaded_video.height
+    
+        # Remove images before the skip and beyond the cap
+        if skip_first_frames != 0:
+            images = images[skip_first_frames:]
+        if frame_load_cap != 0:
+            images = images[skip_first_frames:frame_load_cap]
+        
+        out_images = []
+        for i, image in enumerate(images):
+            if i % select_every_nth == 0:
+                out_images.append(image)
+        
+        out_images = torch.cat(out_images, dim=0)
+    
+        out_images = LoadVideo.force_size(force_size, width, height, out_images)
+    
+        return (out_images, VideoInfo.build_video_info(input_fps, input_frame_count, input_fps, len(out_images)))
+    
+    def load_video_cv(
+            video: str, desired_frame_rate: float, force_size: str, frame_load_cap: int, skip_first_frames: int, select_every_nth: int):
+        
+        def retry_with_pil(video, desired_frame_rate, force_size, frame_load_cap, skip_first_frames, select_every_nth):
+            logger.info(f"Retrying with pil due to opencv error")
+            return LoadVideo.load_video_pil(video, desired_frame_rate, force_size, frame_load_cap, skip_first_frames, select_every_nth)
+        
+        try:
+            video_cap = cv2.VideoCapture(video)
+            if not video_cap.isOpened():
+                return retry_with_pil(video, desired_frame_rate, force_size, frame_load_cap, skip_first_frames, select_every_nth)
+            # set video_cap to look at start_index frame
+            images = []
+            input_frame_count = video_cap.get(cv2.CAP_PROP_FRAME_COUNT)
+            total_frame_count = 0
+            total_frames_evaluated = -1
+            frames_added = 0
+            input_fps = video_cap.get(cv2.CAP_PROP_FPS)
+            input_frame_time = 1/input_fps
+            width = video_cap.get(cv2.CAP_PROP_FRAME_WIDTH)
+            height = video_cap.get(cv2.CAP_PROP_FRAME_HEIGHT)
+            if desired_frame_rate < 0.001:
+                target_frame_time = input_frame_time
+            else:
+                target_frame_time = 1/desired_frame_rate
+            time_offset=target_frame_time - input_frame_time
+            while video_cap.isOpened():
+                if time_offset < target_frame_time:
+                    is_returned, frame = video_cap.read()
+                    # if didn't return frame, video has ended
+                    if not is_returned:
+                        break
+                    time_offset += input_frame_time
+                if time_offset < target_frame_time:
+                    continue
+                time_offset -= target_frame_time
+                # if not at start_index, skip doing anything with frame
+                total_frame_count += 1
+                if total_frame_count <= skip_first_frames:
+                    continue
+                else:
+                    total_frames_evaluated += 1
+    
+                # if should not be selected, skip doing anything with frame
+                if total_frames_evaluated%select_every_nth != 0:
+                    continue
+    
+                # opencv loads images in BGR format (yuck), so need to convert to RGB for ComfyUI use
+                # follow up: can videos ever have an alpha channel?
+                frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                # convert frame to comfyui's expected format (taken from comfy's load image code)
+                image = Image.fromarray(frame)
+                image = ImageOps.exif_transpose(image)
+                image = np.array(image, dtype=np.float32) / 255.0
+                image = torch.from_numpy(image)[None,]
+                images.append(image)
+                frames_added += 1
+                # if cap exists and we've reached it, stop processing frames
+                if frame_load_cap > 0 and frames_added >= frame_load_cap:
+                    break
+        finally:
+            video_cap.release()
+        if len(images) > 0:
+           images = torch.cat(images, dim=0)
+        else:
+            return retry_with_pil(video, desired_frame_rate, force_size, frame_load_cap, skip_first_frames, select_every_nth)
+        
+        images = LoadVideo.force_size(force_size, width, height, images)
+                
+        return (images, VideoInfo.build_video_info(input_fps, input_frame_count, desired_frame_rate, frames_added))
 
 
-class LoadVideoUpload:
+class UploadVideo:
+    
+    UPLOAD_SUBDIRECTORY = "VHS_upload"
+    INPUT_DIR_TYPE_NAMES = ["input", "temp"]
+    
+    def get_selected_upload_directory(upload_to_directory):
+        return os.path.join(folder_paths.get_directory_by_type(upload_to_directory), UploadVideo.UPLOAD_SUBDIRECTORY)
+    
+    def get_full_path(string_from_selector, upload_to_directory):
+        type = upload_to_directory
+        name = string_from_selector
+        
+        # If the string has all three component parts, it's best to get the info directly from there
+        split = re.split(r'[/\\]', string_from_selector)
+        if len(split) == 3:
+            type = split[0]
+            sub = split[1]
+            name = split[2]
+        return os.path.join(UploadVideo.get_selected_upload_directory(type), name)
+            
+    
     @classmethod
     def INPUT_TYPES(s):
-        input_dir = folder_paths.get_input_directory()
         files = []
-        for f in os.listdir(input_dir):
-            if os.path.isfile(os.path.join(input_dir, f)):
-                file_parts = f.split('.')
-                if len(file_parts) > 1 and (file_parts[-1] in video_extensions):
-                    files.append(f)
+        for input_type in s.INPUT_DIR_TYPE_NAMES:
+            input_dir = s.get_selected_upload_directory(input_type)
+            if not os.path.isdir(input_dir):
+                continue
+            for f in os.listdir(input_dir):
+                if os.path.isfile(os.path.join(input_dir, f)):
+                    file_parts = f.split('.')
+                    if len(file_parts) > 1 and (file_parts[-1] in ACCEPTED_VIDEO_EXTENSIONS + ACCEPTED_IMAGE_EXTENSIONS):
+                        files.append(f"{input_type}/{s.UPLOAD_SUBDIRECTORY}/{f}")
         return {"required": {
                     "video": (sorted(files), {"video_upload": True}),
-                     "force_rate": ("INT", {"default": 0, "min": 0, "max": 24, "step": 1}),
-                     "force_size": (["Disabled", "256x?", "?x256", "256x256", "512x?", "?x512", "512x512"],),
-                     "frame_load_cap": ("INT", {"default": 0, "min": 0, "step": 1}),
-                     "skip_first_frames": ("INT", {"default": 0, "min": 0, "step": 1}),
-                     "select_every_nth": ("INT", {"default": 1, "min": 1, "step": 1}),
-                     },}
-
-    CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
-
-    RETURN_TYPES = ("IMAGE", "INT",)
-    RETURN_NAMES = ("IMAGE", "frame_count",)
-    FUNCTION = "load_video"
-
-    known_exceptions = []
-    def load_video(self, **kwargs):
-        try:
-            return load_video_cv(**kwargs)
-        except Exception as e:
-            raise RuntimeError(f"Failed to load video: {kwargs['video']}\ndue to: {e.__str__()}")
-
-    @classmethod
-    def IS_CHANGED(s, video, **kwargs):
-        image_path = folder_paths.get_annotated_filepath(video)
-        return calculate_file_hash(image_path)
-
-    @classmethod
-    def VALIDATE_INPUTS(s, video, **kwargs):
-        if not folder_paths.exists_annotated_filepath(video):
-            return "Invalid video file: {}".format(video)
-        return True
-
-
-class LoadVideoPath:
-    @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "video": ("STRING", {"default": "X://insert/path/here.mp4"}),
-                "force_rate": ("INT", {"default": 0, "min": 0, "max": 24, "step": 1}),
-                "force_size": (["Disabled", "256x?", "?x256", "256x256", "512x?", "?x512", "512x512"],),
-                "frame_load_cap": ("INT", {"default": 0, "min": 0, "step": 1}),
-                "skip_first_frames": ("INT", {"default": 0, "min": 0, "step": 1}),
-                "select_every_nth": ("INT", {"default": 1, "min": 1, "step": 1}),
-            },
+                    "upload_to_directory": (s.INPUT_DIR_TYPE_NAMES,),
+                    },
         }
 
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
 
-    RETURN_TYPES = ("IMAGE", "INT",)
-    RETURN_NAMES = ("IMAGE", "frame_count",)
-    FUNCTION = "load_video"
-
-    known_exceptions = []
-    def load_video(self, **kwargs):
-        try:
-            return load_video_cv(**kwargs)
-        except Exception as e:
-            raise RuntimeError(f"Failed to load video: {kwargs['video']}\ndue to: {e.__str__()}")
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("video_path",)
+    FUNCTION = "upload_video"
+    
+    def upload_video(self, video, upload_to_directory):
+        return (UploadVideo.get_full_path(video, upload_to_directory),)
 
     @classmethod
-    def IS_CHANGED(s, video, **kwargs):
-        return calculate_file_hash(video.strip("\""))
+    def IS_CHANGED(s, video, upload_to_directory, **kwargs):
+        if video is None: # If "video" is a pin
+            print(f'running IS_CHANGED, video is None')
+            return ''
+        return calculate_file_hash(UploadVideo.get_full_path(video, upload_to_directory))
 
     @classmethod
-    def VALIDATE_INPUTS(s, video, **kwargs):
-        if not os.path.isfile(video.strip("\"")):
-            return "Invalid video file: {}".format(video)
+    def VALIDATE_INPUTS(s, video, upload_to_directory, **kwargs):
+        full_path = UploadVideo.get_full_path(video, upload_to_directory)
+        if not os.path.isfile(full_path):
+            return f"Invalid video file: {full_path}"
         return True

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -10,7 +10,7 @@ from PIL.PngImagePlugin import PngInfo
 import folder_paths
 from .logger import logger
 from .image_latent_nodes import DuplicateImages, DuplicateLatents, GetImageCount, GetLatentCount, MergeImages, MergeLatents, SelectEveryNthImage, SelectEveryNthLatent, SplitLatents, SplitImages
-from .load_video_nodes import LoadVideoUpload, LoadVideoPath
+from .load_video_nodes import LoadVideo, UploadVideo, OutVideoInfo
 from .load_images_nodes import LoadImagesFromDirectoryUpload, LoadImagesFromDirectoryPath
 
 folder_paths.folder_names_and_paths["video_formats"] = (
@@ -219,10 +219,11 @@ class VideoCombine:
 
 NODE_CLASS_MAPPINGS = {
     "VHS_VideoCombine": VideoCombine,
-    "VHS_LoadVideo": LoadVideoUpload,
-    "VHS_LoadVideoPath": LoadVideoPath,
+    "VHS_LoadVideo": LoadVideo,
+    "VHS_OutVideoInfo": OutVideoInfo,
     "VHS_LoadImages": LoadImagesFromDirectoryUpload,
     "VHS_LoadImagesPath": LoadImagesFromDirectoryPath,
+    "VHS_UploadVideo": UploadVideo,
     # Latent and Image nodes
     "VHS_SplitLatents": SplitLatents,
     "VHS_SplitImages": SplitImages,
@@ -237,10 +238,11 @@ NODE_CLASS_MAPPINGS = {
 }
 NODE_DISPLAY_NAME_MAPPINGS = {
     "VHS_VideoCombine": "Video Combine 🎥🅥🅗🅢",
-    "VHS_LoadVideo": "Load Video (Upload) 🎥🅥🅗🅢",
-    "VHS_LoadVideoPath": "Load Video (Path) 🎥🅥🅗🅢",
+    "VHS_LoadVideo": "Load Video 🎥🅥🅗🅢",
+    "VHS_OutVideoInfo": "Output Video Info 🎥🅥🅗🅢",
     "VHS_LoadImages": "Load Images (Upload) 🎥🅥🅗🅢",
     "VHS_LoadImagesPath": "Load Images (Path) 🎥🅥🅗🅢",
+    "VHS_UploadVideo": "Upload Video 🎥🅥🅗🅢",
     # Latent and Image nodes
     "VHS_SplitLatents": "Split Latent Batch 🎥🅥🅗🅢",
     "VHS_SplitImages": "Split Image Batch 🎥🅥🅗🅢",

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -10,7 +10,7 @@ from PIL.PngImagePlugin import PngInfo
 import folder_paths
 from .logger import logger
 from .image_latent_nodes import DuplicateImages, DuplicateLatents, GetImageCount, GetLatentCount, MergeImages, MergeLatents, SelectEveryNthImage, SelectEveryNthLatent, SplitLatents, SplitImages
-from .load_video_nodes import LoadVideo, UploadVideo, OutVideoInfo
+from .load_video_nodes import LoadVideo, LoadVideoUpload, UploadVideo, OutVideoInfo
 from .load_images_nodes import LoadImagesFromDirectoryUpload, LoadImagesFromDirectoryPath
 
 folder_paths.folder_names_and_paths["video_formats"] = (
@@ -219,7 +219,8 @@ class VideoCombine:
 
 NODE_CLASS_MAPPINGS = {
     "VHS_VideoCombine": VideoCombine,
-    "VHS_LoadVideo": LoadVideo,
+    "VHS_LoadVideoPath": LoadVideo,
+    "VHS_LoadVideoUpload": LoadVideoUpload,
     "VHS_OutVideoInfo": OutVideoInfo,
     "VHS_LoadImages": LoadImagesFromDirectoryUpload,
     "VHS_LoadImagesPath": LoadImagesFromDirectoryPath,
@@ -238,7 +239,8 @@ NODE_CLASS_MAPPINGS = {
 }
 NODE_DISPLAY_NAME_MAPPINGS = {
     "VHS_VideoCombine": "Video Combine 🎥🅥🅗🅢",
-    "VHS_LoadVideo": "Load Video 🎥🅥🅗🅢",
+    "VHS_LoadVideoPath": "Load Video 🎥🅥🅗🅢",
+    "VHS_LoadVideoUpload": "Load Video Upload 🎥🅥🅗🅢",
     "VHS_OutVideoInfo": "Output Video Info 🎥🅥🅗🅢",
     "VHS_LoadImages": "Load Images (Upload) 🎥🅥🅗🅢",
     "VHS_LoadImagesPath": "Load Images (Path) 🎥🅥🅗🅢",

--- a/web/js/gif_preview.js
+++ b/web/js/gif_preview.js
@@ -1,154 +1,228 @@
 import { app } from '../../../scripts/app.js'
 import { api } from '../../../scripts/api.js'
 
+export const acceptableFileTypes = [
+	"video/webm", "video/mp4", "video/mkv",
+	"image/webp", "image/gif", "image/apng", "image/mjpeg"
+];
+
 function offsetDOMWidget(
-    widget,
-    ctx,
-    node,
-    widgetWidth,
-    widgetY,
-    height
-  ) {
-    const margin = 10
-    const elRect = ctx.canvas.getBoundingClientRect()
-    const transform = new DOMMatrix()
-      .scaleSelf(
-        elRect.width / ctx.canvas.width,
-        elRect.height / ctx.canvas.height
-      )
-      .multiplySelf(ctx.getTransform())
-      .translateSelf(0, widgetY + margin)
-  
-    const scale = new DOMMatrix().scaleSelf(transform.a, transform.d)
-    Object.assign(widget.inputEl.style, {
-      transformOrigin: '0 0',
-      transform: scale,
-      left: `${transform.e}px`,
-      top: `${transform.d + transform.f}px`,
-      width: `${widgetWidth}px`,
-      height: `${(height || widget.parent?.inputHeight || 32) - margin}px`,
-      position: 'absolute',
-      background: !node.color ? '' : node.color,
-      color: !node.color ? '' : 'white',
-      zIndex: 5, //app.graph._nodes.indexOf(node),
-    })
-  }
+	widget,
+	ctx,
+	node,
+	widgetWidth,
+	widgetY,
+	height
+) {
+	const margin = 10
+	const elRect = ctx.canvas.getBoundingClientRect()
+	const transform = new DOMMatrix()
+		.scaleSelf(
+			elRect.width / ctx.canvas.width,
+			elRect.height / ctx.canvas.height
+		)
+		.multiplySelf(ctx.getTransform())
+		.translateSelf(0, widgetY + margin)
 
-  export const hasWidgets = (node) => {
-    if (!node.widgets || !node.widgets?.[Symbol.iterator]) {
-      return false
-    }
-    return true
-  }
+	const scale = new DOMMatrix().scaleSelf(transform.a, transform.d)
+	Object.assign(widget.inputEl.style, {
+		transformOrigin: '0 0',
+		transform: scale,
+		left: `${transform.e}px`,
+		top: `${transform.d + transform.f}px`,
+		width: `${widgetWidth}px`,
+		height: `${(height || widget.parent?.inputHeight || 32) - margin}px`,
+		position: 'absolute',
+		background: !node.color ? '' : node.color,
+		color: !node.color ? '' : 'white',
+		zIndex: 5, //app.graph._nodes.indexOf(node),
+	})
+}
 
-  export const cleanupNode = (node) => {
-    if (!hasWidgets(node)) {
-      return
-    }
-  
-    for (const w of node.widgets) {
-      if (w.canvas) {
-        w.canvas.remove()
-      }
-      if (w.inputEl) {
-        w.inputEl.remove()
-      }
-      // calls the widget remove callback
-      w.onRemoved?.()
-    }
-  }
+export const hasWidgets = (node) => {
+	if (!node.widgets || !node.widgets?.[Symbol.iterator]) {
+		return false
+	}
+	return true
+}
+
+export const cleanupNode = (node) => {
+	if (!hasWidgets(node)) {
+		return
+	}
+
+	for (const w of node.widgets) {
+		if (w.canvas) {
+			w.canvas.remove()
+		}
+		if (w.inputEl) {
+			w.inputEl.remove()
+		}
+		// calls the widget remove callback
+		w.onRemoved?.()
+	}
+}
 
 const CreatePreviewElement = (name, val, format) => {
-  const [type] = format.split('/')  
-  const w = {
-      name,
-      type,
-      value: val,
-      draw: function (ctx, node, widgetWidth, widgetY, height) {
-        const [cw, ch] = this.computeSize(widgetWidth)
-        offsetDOMWidget(this, ctx, node, widgetWidth, widgetY, ch)
-      },
-      computeSize: function (_) {
-        const ratio = this.inputRatio || 1
-        const width = Math.max(220, this.parent.size[0])
-        return [width, (width / ratio + 10)]
-      },
-      onRemoved: function () {
-        if (this.inputEl) {
-          this.inputEl.remove()
-        }
-      },
-    }
+	const [type] = format.split('/')
+	const w = {
+		name,
+		type,
+		value: val,
+		draw: function(ctx, node, widgetWidth, widgetY, height) {
+			const [cw, ch] = this.computeSize(widgetWidth)
+			offsetDOMWidget(this, ctx, node, widgetWidth, widgetY, ch)
+		},
+		computeSize: function(_) {
+			const ratio = this.inputRatio || 1
+			const width = Math.max(220, this.parent.size[0])
+			return [width, (width / ratio + 10)]
+		},
+		onRemoved: function() {
+			if (this.inputEl) {
+				this.inputEl.remove()
+			}
+		},
+	}
 
-    w.inputEl = document.createElement(type === 'video' ? 'video' : 'img')
-    w.inputEl.src = w.value
-    if (type === 'video') {
-      w.inputEl.setAttribute('type', 'video/webm');
-      w.inputEl.autoplay = true
-      w.inputEl.loop = true
-      w.inputEl.controls = false;
-    }
-    w.inputEl.onload = function () {
-      w.inputRatio = w.inputEl.naturalWidth / w.inputEl.naturalHeight
-    }
-    document.body.appendChild(w.inputEl)
-    const videoElements = document.querySelectorAll('video');
-      videoElements.forEach(video => {
-        video.currentTime = 0;
-      });
-    return w
-  }
+	w.inputEl = document.createElement(type === 'video' ? 'video' : 'img')
+	w.inputEl.src = w.value
+
+	w.inputEl.onload = function() {
+		w.inputRatio = w.inputEl.naturalWidth / w.inputEl.naturalHeight
+
+		if (type === 'video') {
+			setTimeout(_=>{
+				w.inputEl.setAttribute('type', 'video/webm');
+				w.inputEl.muted = true;
+				w.inputEl.autoplay = true
+				w.inputEl.loop = true
+				w.inputEl.controls = false;
+			},100);
+		}
+	}
+	document.body.appendChild(w.inputEl)
+	const videoElements = document.querySelectorAll('video');
+	videoElements.forEach(video => {
+		video.currentTime = 0;
+	});
+	return w
+}
 
 const gif_preview = {
-    name: 'VideoHelperSuite.gif_preview',
-    async beforeRegisterNodeDef(nodeType, nodeData, app) {
-        switch (nodeData.name) {
-            case 'VHS_VideoCombine':{
-              nodeType.prototype.onNodeCreated = function () {
-                this.addWidget("button", "Sync playback", null, () => {
-                  const videoElements = document.querySelectorAll('video');
-                  videoElements.forEach(video => {
-                    video.currentTime = 0;
-                  });
-                });
-              }
-                const onExecuted = nodeType.prototype.onExecuted
-                nodeType.prototype.onExecuted = function (message) {
-                const prefix = 'vhs_gif_preview_'
-                const r = onExecuted ? onExecuted.apply(this, message) : undefined
+	name: 'VideoHelperSuite.gif_preview',
+	async beforeRegisterNodeDef(nodeType, nodeData, app) {
+		switch (nodeData.name) {
+			case 'VHS_VideoCombine': {
+				nodeType.prototype.onNodeCreated = function() {
+					this.addWidget("button", "Sync playback", null, () => {
+						const videoElements = document.querySelectorAll('video');
+						videoElements.forEach(video => {
+							video.currentTime = 0;
+						});
+					});
+				}
+				const onExecuted = nodeType.prototype.onExecuted
+				nodeType.prototype.onExecuted = function(message) {
+					const prefix = 'vhs_gif_preview_'
+					const r = onExecuted ? onExecuted.apply(this, message) : undefined
 
-                if (this.widgets) {
-                    const pos = this.widgets.findIndex((w) => w.name === `${prefix}_0`)
-                    if (pos !== -1) {
-                      for (let i = pos; i < this.widgets.length; i++) {
-                        this.widgets[i].onRemoved?.()
-                    }
-                    this.widgets.length = pos
-                    }
-                    if (message?.gifs) {
-                      message.gifs.forEach((params, i) => {
-                        const previewUrl = api.apiURL(
-                          '/view?' + new URLSearchParams(params).toString()
-                        )
-                  const w = this.addCustomWidget(
-                    CreatePreviewElement(`${prefix}_${i}`, previewUrl, params.format || 'image/gif')
-                  )
-                  w.parent = this
-                  })
-                 }
-                  const onRemoved = this.onRemoved
-                  this.onRemoved = () => {
-                    cleanupNode(this)
-                    return onRemoved?.()
-                  }
-                }
-                this.setSize([this.size[0], this.computeSize([this.size[0], this.size[1]])[1]])
-                return r
-                }
-                break
-              }
-        }
-    }
+					if (this.widgets) {
+						const pos = this.widgets.findIndex((w) => w.name === `${prefix}_0`)
+						if (pos !== -1) {
+							for (let i = pos; i < this.widgets.length; i++) {
+								this.widgets[i].onRemoved?.()
+							}
+							this.widgets.length = pos
+						}
+						if (message?.gifs) {
+							message.gifs.forEach((params, i) => {
+								const previewUrl = api.apiURL(
+									'/view?' + new URLSearchParams(params).toString()
+								)
+								const w = this.addCustomWidget(
+									CreatePreviewElement(`${prefix}_${i}`, previewUrl, params.format || 'image/gif')
+								)
+								w.parent = this
+							})
+						}
+						const onRemoved = this.onRemoved
+						this.onRemoved = () => {
+							cleanupNode(this)
+							return onRemoved?.()
+						}
+					}
+					this.setSize([this.size[0], this.computeSize([this.size[0], this.size[1]])[1]])
+					return r
+				}
+				break
+			}
+			case 'VHS_UploadVideo': {
+				const onAdded = nodeType.prototype.onAdded;
+				nodeType.prototype.onAdded = function() {
+					onAdded?.apply(this, arguments);
+
+					const node = this;
+					const videoWidget = node.widgets.find((w) => w.name === "video");
+
+					const cb = node.callback;
+					videoWidget.callback = function(message) {
+						const components = videoWidget.value.split('/');
+
+						let type = '';
+						let subfolder = '';
+						let name = '';
+
+						if (components.length === 3) {
+							[type, subfolder, name] = components;
+						} else if (components.length === 2) {
+							[type, name] = components;
+						} else {
+							name = components[0];
+						}
+
+						const extSplit = name.split('.');
+						const extension = extSplit[extSplit.length - 1];
+
+						const prefix = 'vhs_gif_preview_';
+						const r = cb ? cb.apply(node, message) : undefined;
+
+						if (node.widgets) {
+							const pos = node.widgets.findIndex((w) => w.name === `${prefix}_0`);
+							if (pos !== -1) {
+								for (let i = pos; i < node.widgets.length; i++) {
+									node.widgets[i].onRemoved?.();
+								}
+								node.widgets.length = pos;
+							}
+							const previewUrl = api.apiURL(
+								'/view?filename=' + name + '&type=' + type + '&subfolder=' + subfolder
+							);
+
+							let format = 'video/webm';
+							for (const fileType of acceptableFileTypes) {
+								if (fileType.includes(extension)) {
+									format = fileType;
+								}
+							}
+							const w = node.addCustomWidget(
+								CreatePreviewElement(`${prefix}_${0}`, previewUrl, format || 'image/gif')
+							);
+							w.parent = node;
+						}
+						const onRemoved = node.onRemoved;
+						node.onRemoved = () => {
+							cleanupNode(node);
+							return onRemoved?.();
+						};
+						node.setSize([node.size[0], node.computeSize([node.size[0], node.size[1]])[1]]);
+						return r;
+					}
+				};
+			};
+				break;
+		}
+	}
 }
 
 app.registerExtension(gif_preview)

--- a/web/js/gif_preview.js
+++ b/web/js/gif_preview.js
@@ -157,6 +157,8 @@ const gif_preview = {
 				}
 				break
 			}
+			case "VHS_LoadVideoUpload":
+				// Fall into next case
 			case 'VHS_UploadVideo': {
 				const onAdded = nodeType.prototype.onAdded;
 				nodeType.prototype.onAdded = function() {

--- a/web/js/videoupload.js
+++ b/web/js/videoupload.js
@@ -4,115 +4,117 @@ import { ComfyWidgets } from "../../../scripts/widgets.js"
 import { acceptableFileTypes } from "./gif_preview.js"
 
 function videoUpload(node, inputName, inputData, app) {
-    const videoWidget = node.widgets.find((w) => w.name === "video");
-    const typeWidget = node.widgets.find((w) => w.name === "upload_to_directory");
-    let uploadWidget;
-    
-    // Clear widget value if temp since it didn't survive the relaunch
-    if (videoWidget.value.startsWith("temp/")) {
+	const videoWidget = node.widgets.find((w) => w.name === "video");
+	const typeWidget = node.widgets.find((w) => w.name === "upload_to_directory");
+	let uploadWidget;
+
+	console.log(videoWidget);
+
+	// Clear widget value if temp since it didn't survive the relaunch
+	if (videoWidget.value != undefined && videoWidget.value.startsWith("temp/")) {
 		videoWidget.value = "";
 	}
 
-    var default_value = videoWidget.value;
-    Object.defineProperty(videoWidget, "value", {
-        set : function(value) {
-            this._real_value = value;
-        },
+	var default_value = videoWidget.value;
+	Object.defineProperty(videoWidget, "value", {
+		set: function(value) {
+			this._real_value = value;
+		},
 
-        get : function() {
-            let value = "";
-            if (this._real_value) {
-                value = this._real_value;
-            } else {
-                return default_value;
-            }
+		get: function() {
+			let value = "";
+			if (this._real_value) {
+				value = this._real_value;
+			} else {
+				return default_value;
+			}
 
-            if (value.filename) {
-                let real_value = value;
-                value = "";
-                if (real_value.subfolder) {
-                    value = real_value.subfolder + "/";
-                }
+			if (value.filename) {
+				let real_value = value;
+				value = "";
+				if (real_value.subfolder) {
+					value = real_value.subfolder + "/";
+				}
 
-                value += real_value.filename;
+				value += real_value.filename;
 
-                if(real_value.type && real_value.type !== "input")
-                    value += ` [${real_value.type}]`;
-            }
-            return value;
-        }
-    });
-    async function uploadFile(file, node, updateNode, pasted = false) {
-        try {
-            // Wrap file in formdata so it includes filename
-            const body = new FormData();
-            body.append("image", file);
-            body.append("type", typeWidget.value);
-            body.append("subfolder", "VHS_upload");
-            const resp = await api.fetchApi("/upload/image", {
-                method: "POST",
-                body,
-            });
+				if (real_value.type && real_value.type !== "input")
+					value += ` [${real_value.type}]`;
+			}
+			return value;
+		}
+	});
+	async function uploadFile(file, node, updateNode, pasted = false) {
+		try {
+			// Wrap file in formdata so it includes filename
+			const body = new FormData();
+			body.append("image", file);
+			body.append("type", typeWidget.value);
+			body.append("subfolder", "VHS_upload");
+			const resp = await api.fetchApi("/upload/image", {
+				method: "POST",
+				body,
+			});
 
-            if (resp.status === 200) {
-                const data = await resp.json();
-                // Add the file to the dropdown list and update the widget value
-                let path = data.name;
-                if (data.subfolder) path = data.subfolder + "/" + path;
-                if (data.type) path = data.type + "/" + path;
+			if (resp.status === 200) {
+				const data = await resp.json();
+				// Add the file to the dropdown list and update the widget value
+				let path = data.name;
+				if (data.subfolder) path = data.subfolder + "/" + path;
+				if (data.type) path = data.type + "/" + path;
 
-                if (!videoWidget.options.values.includes(path)) {
-                    videoWidget.options.values.push(path);
-                }
+				if (!videoWidget.options.values.includes(path)) {
+					videoWidget.options.values.push(path);
+				}
 
-                if (updateNode) {
-                    	videoWidget.value = path;
-                    	videoWidget.callback(path); // Update video container
-                }
-            } else {
-                alert(resp.status + " - " + resp.statusText);
-            }
-        } catch (error) {
-            alert(error);
-        }
-    }
+				if (updateNode) {
+					videoWidget.value = path;
+					videoWidget.callback(path); // Update video container
+				}
+			} else {
+				alert(resp.status + " - " + resp.statusText);
+			}
+		} catch (error) {
+			alert(error);
+		}
+	}
 
-    const fileInput = document.createElement("input");
-    Object.assign(fileInput, {
-        type: "file",
-        accept: acceptableFileTypes.join(","),
-        style: "display: none",
-        onchange: async () => {
-            if (fileInput.files.length) {
-                await uploadFile(fileInput.files[0], node, true);
-            }
-        },
-    });
-    document.body.append(fileInput);
+	const fileInput = document.createElement("input");
+	Object.assign(fileInput, {
+		type: "file",
+		accept: acceptableFileTypes.join(","),
+		style: "display: none",
+		onchange: async () => {
+			if (fileInput.files.length) {
+				await uploadFile(fileInput.files[0], node, true);
+			}
+		},
+	});
+	document.body.append(fileInput);
 
-    // Create the button widget for selecting the files
-    uploadWidget = node.addWidget("button", "choose file or drag and drop to upload", "video", () => {
-        fileInput.click();
-    });
-    uploadWidget.serialize = false;		
-    
-    // Add handler to check if an image is being dragged over our node
-	node.onDragOver = function (e) {
-	    if (e.dataTransfer && e.dataTransfer.items) {
-	        // Check if any of the dragged files are images or videos
-	        for (const file of e.dataTransfer.items) {
+	// Create the button widget for selecting the files
+	uploadWidget = node.addWidget("button", "choose file or drag and drop to upload", "video", () => {
+		fileInput.click();
+	});
+	uploadWidget.serialize = false;
+
+	// Add handler to check if an image is being dragged over our node
+	node.onDragOver = function(e) {
+		if (e.dataTransfer && e.dataTransfer.items) {
+			// Check if any of the dragged files are images or videos
+			for (const file of e.dataTransfer.items) {
 				if (acceptableFileTypes.includes(file.type)) {
 					return true;
 				}
 			}
-	    }
-	
-	    return false;
+		}
+
+		return false;
 	};
 
 	// On drop upload files
-	node.onDragDrop = function (e) {
-	    if (e.dataTransfer && e.dataTransfer.files) {
+	node.onDragDrop = function(e) {
+		if (e.dataTransfer && e.dataTransfer.files) {
 			for (const file of e.dataTransfer.files) {
 				if (acceptableFileTypes.includes(file.type)) {
 					uploadFile(file, node, true); // Just upload the very first matching object in the payload
@@ -120,11 +122,11 @@ function videoUpload(node, inputName, inputData, app) {
 				}
 			}
 		}
-		
+
 		return false;
 	};
 
-    return { widget: uploadWidget };
+	return { widget: uploadWidget };
 }
 
 ComfyWidgets.VIDEOUPLOAD = videoUpload;
@@ -132,8 +134,12 @@ ComfyWidgets.VIDEOUPLOAD = videoUpload;
 app.registerExtension({
 	name: "VideoHelperSuite.UploadVideo",
 	async beforeRegisterNodeDef(nodeType, nodeData, app) {
-		if (nodeData?.name == "VHS_UploadVideo") {
-			nodeData.input.required.upload = ["VIDEOUPLOAD"];
+		switch (nodeData?.name) {
+			case "VHS_LoadVideoUpload":
+				// Fall into next case
+			case 'VHS_UploadVideo': {
+				nodeData.input.required.upload = ["VIDEOUPLOAD"];
+			}
 		}
 	}
 });

--- a/web/js/videoupload.js
+++ b/web/js/videoupload.js
@@ -1,13 +1,20 @@
 import { app } from "../../../scripts/app.js";
 import { api } from '../../../scripts/api.js'
 import { ComfyWidgets } from "../../../scripts/widgets.js"
+import { acceptableFileTypes } from "./gif_preview.js"
 
 function videoUpload(node, inputName, inputData, app) {
-    const imageWidget = node.widgets.find((w) => w.name === "video");
+    const videoWidget = node.widgets.find((w) => w.name === "video");
+    const typeWidget = node.widgets.find((w) => w.name === "upload_to_directory");
     let uploadWidget;
+    
+    // Clear widget value if temp since it didn't survive the relaunch
+    if (videoWidget.value.startsWith("temp/")) {
+		videoWidget.value = "";
+	}
 
-    var default_value = imageWidget.value;
-    Object.defineProperty(imageWidget, "value", {
+    var default_value = videoWidget.value;
+    Object.defineProperty(videoWidget, "value", {
         set : function(value) {
             this._real_value = value;
         },
@@ -35,12 +42,13 @@ function videoUpload(node, inputName, inputData, app) {
             return value;
         }
     });
-    async function uploadFile(file, updateNode, pasted = false) {
+    async function uploadFile(file, node, updateNode, pasted = false) {
         try {
             // Wrap file in formdata so it includes filename
             const body = new FormData();
             body.append("image", file);
-            if (pasted) body.append("subfolder", "pasted");
+            body.append("type", typeWidget.value);
+            body.append("subfolder", "VHS_upload");
             const resp = await api.fetchApi("/upload/image", {
                 method: "POST",
                 body,
@@ -51,13 +59,15 @@ function videoUpload(node, inputName, inputData, app) {
                 // Add the file to the dropdown list and update the widget value
                 let path = data.name;
                 if (data.subfolder) path = data.subfolder + "/" + path;
+                if (data.type) path = data.type + "/" + path;
 
-                if (!imageWidget.options.values.includes(path)) {
-                    imageWidget.options.values.push(path);
+                if (!videoWidget.options.values.includes(path)) {
+                    videoWidget.options.values.push(path);
                 }
 
                 if (updateNode) {
-                    imageWidget.value = path;
+                    	videoWidget.value = path;
+                    	videoWidget.callback(path); // Update video container
                 }
             } else {
                 alert(resp.status + " - " + resp.statusText);
@@ -70,31 +80,60 @@ function videoUpload(node, inputName, inputData, app) {
     const fileInput = document.createElement("input");
     Object.assign(fileInput, {
         type: "file",
-        accept: "video/webm,video/mp4,video/mkv,image/gif",
+        accept: acceptableFileTypes.join(","),
         style: "display: none",
         onchange: async () => {
             if (fileInput.files.length) {
-                await uploadFile(fileInput.files[0], true);
+                await uploadFile(fileInput.files[0], node, true);
             }
         },
     });
     document.body.append(fileInput);
 
     // Create the button widget for selecting the files
-    uploadWidget = node.addWidget("button", "choose file to upload", "video", () => {
+    uploadWidget = node.addWidget("button", "choose file or drag and drop to upload", "video", () => {
         fileInput.click();
     });
-    uploadWidget.serialize = false;
+    uploadWidget.serialize = false;		
+    
+    // Add handler to check if an image is being dragged over our node
+	node.onDragOver = function (e) {
+	    if (e.dataTransfer && e.dataTransfer.items) {
+	        // Check if any of the dragged files are images or videos
+	        for (const file of e.dataTransfer.items) {
+				if (acceptableFileTypes.includes(file.type)) {
+					return true;
+				}
+			}
+	    }
+	
+	    return false;
+	};
+
+	// On drop upload files
+	node.onDragDrop = function (e) {
+	    if (e.dataTransfer && e.dataTransfer.files) {
+			for (const file of e.dataTransfer.files) {
+				if (acceptableFileTypes.includes(file.type)) {
+					uploadFile(file, node, true); // Just upload the very first matching object in the payload
+					return true;
+				}
+			}
+		}
+		
+		return false;
+	};
+
     return { widget: uploadWidget };
 }
+
 ComfyWidgets.VIDEOUPLOAD = videoUpload;
 
 app.registerExtension({
 	name: "VideoHelperSuite.UploadVideo",
 	async beforeRegisterNodeDef(nodeType, nodeData, app) {
-		if (nodeData?.name == "VHS_LoadVideo") {
-            console.log("test")
+		if (nodeData?.name == "VHS_UploadVideo") {
 			nodeData.input.required.upload = ["VIDEOUPLOAD"];
 		}
-	},
+	}
 });


### PR DESCRIPTION
…support webp, apng, mjpeg

-Add PIL fallback to LoadVideo to support video types not supported by opencv2, such as webp, apng, and mjpeg. Changing frame rate is not supported in this mode. The output log will inform you of this when the fallback is used. 
-Added a video_info output to LoadVideo which includes more information, such as the frame count, fps, duration and frame time for the input video and the output frames 
-Added a new node UploadVideo which includes the functionality of LoadVideoUpload insofar as copying a video to the input folder but also allows the user to upload to temp instead for testing so as not to clutter the input folder. Uploaded videos now go to a subfolder, 'VHS_upload'. 
-Added gif preview to UploadVideo so uploaded videos can be viewed on the node when selected. 
-Fixed autoplay for gif preview on VideoCombine, still not working for videos on UploadVideo node. 
-Added drag and drop for videos on UploadVideo node. 
-Changed 'force_frame_rate' to 'desired_frame_rate' because it cannot be forced in PIL fallback, this is an effort to communicate this to the user
-Bring LoadVideoUpload features up to parity with LoadVideoPath and UploadVideo
-Add guard clause for undefined video widget value