### PR TITLE
Remove unnecessary underscore from saved file names

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -3,6 +3,7 @@ import json
 import subprocess
 import shutil
 import numpy as np
+import re
 from typing import List
 from PIL import Image
 from PIL.PngImagePlugin import PngInfo
@@ -130,11 +131,22 @@ class VideoCombine:
                 metadata.add_text(x, json.dumps(extra_pnginfo[x]))
                 video_metadata[x] = extra_pnginfo[x]
 
-        counter = 1 
+        # comfy counter workaround
+        max_counter = 0
 
+        # Loop through the existing files
         for existing_file in os.listdir(full_output_folder):
-            if existing_file.startswith(f"{filename}_") and existing_file.endswith(".png"):
-                counter += 1
+            # Check if the file matches the expected format
+            match = re.fullmatch(f"{filename}_(\d+)_?\.[a-zA-Z0-9]+", existing_file)
+            if match:
+                # Extract the numeric portion of the filename
+                file_counter = int(match.group(1))
+                # Update the maximum counter value if necessary
+                if file_counter > max_counter:
+                    max_counter = file_counter
+
+        # Increment the counter by 1 to get the next available value
+        counter = max_counter + 1
 
         # save first frame as png to keep metadata
         file = f"{filename}_{counter:05}.png"

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -115,7 +115,7 @@ class VideoCombine:
         (
             full_output_folder,
             filename,
-            counter,
+            _,
             subfolder,
             _,
         ) = folder_paths.get_save_image_path(filename_prefix, output_dir)
@@ -130,8 +130,14 @@ class VideoCombine:
                 metadata.add_text(x, json.dumps(extra_pnginfo[x]))
                 video_metadata[x] = extra_pnginfo[x]
 
+        counter = 1 
+
+        for existing_file in os.listdir(full_output_folder):
+            if existing_file.startswith(f"{filename}_") and existing_file.endswith(".png"):
+                counter += 1
+
         # save first frame as png to keep metadata
-        file = f"{filename}_{counter:05}_.png"
+        file = f"{filename}_{counter:05}.png"
         file_path = os.path.join(full_output_folder, file)
         frames[0].save(
             file_path,

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -131,7 +131,7 @@ class VideoCombine:
                 video_metadata[x] = extra_pnginfo[x]
 
         # save first frame as png to keep metadata
-        file = f"{filename}_{counter:05}.png"
+        file = f"{filename}_{counter:05}_.png"
         file_path = os.path.join(full_output_folder, file)
         frames[0].save(
             file_path,

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -131,7 +131,7 @@ class VideoCombine:
                 video_metadata[x] = extra_pnginfo[x]
 
         # save first frame as png to keep metadata
-        file = f"{filename}_{counter:05}_.png"
+        file = f"{filename}_{counter:05}.png"
         file_path = os.path.join(full_output_folder, file)
         frames[0].save(
             file_path,
@@ -142,7 +142,7 @@ class VideoCombine:
             frames = frames + frames[-2:0:-1]
 
         format_type, format_ext = format.split("/")
-        file = f"{filename}_{counter:05}_.{format_ext}"
+        file = f"{filename}_{counter:05}.{format_ext}"
         file_path = os.path.join(full_output_folder, file)
         if format_type == "image":
             # Use pillow directly to save an animated image
@@ -164,7 +164,7 @@ class VideoCombine:
             video_format_path = folder_paths.get_full_path("video_formats", format_ext + ".json")
             with open(video_format_path, 'r') as stream:
                 video_format = json.load(stream)
-            file = f"{filename}_{counter:05}_.{video_format['extension']}"
+            file = f"{filename}_{counter:05}.{video_format['extension']}"
             file_path = os.path.join(full_output_folder, file)
             dimensions = f"{frames[0].width}x{frames[0].height}"
             metadata_args = ["-metadata", "comment=" + json.dumps(video_metadata)]


### PR DESCRIPTION
Some Windows software seem to have issues loading filenames that end with underscore, and it otherwise seems unnecessary and remnant of something Comfy did in the past...