### PR TITLE
fix: batch image load with masks

### DIFF
--- a/videohelpersuite/load_images_nodes.py
+++ b/videohelpersuite/load_images_nodes.py
@@ -62,12 +62,14 @@ def load_images(directory: str, image_load_cap: int = 0, skip_first_images: int 
         if 'A' in i.getbands():
             mask = np.array(i.getchannel('A')).astype(np.float32) / 255.0
             mask = 1. - torch.from_numpy(mask)
-        else:
-            mask = torch.zeros((64,64), dtype=torch.float32, device="cpu")
+            masks.append(mask)
         images.append(image)
-        masks.append(mask)
         image_count += 1
     
+    if len(masks) != len(images):
+        logger.warning(f"Only {len(masks)} masks were loaded, but {len(images)} images were loaded. Ignoring masks.")
+        masks = [torch.zeros((64,64), dtype=torch.float32, device="cpu")] * len(images)
+
     if len(images) == 0:
         raise FileNotFoundError(f"No images could be loaded from directory '{directory}'.")
 


### PR DESCRIPTION
I was trying to break the video into frames, and found some frames may have 4 channels (with 'A'). It may fail since the tensor requires the same shape for every mask.

Here, I added a check, if no mask or `len(masks)` is not equal to `len(images)`, it will fill fake masks.

<img width="837" alt="image" src="https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/assets/23226810/cf01ebda-680b-4f6a-bd74-a46e96dd1b1d">
