### PR TITLE
Video format should upgrade.

### DIFF
--- a/video_formats/h264-mp4.json
+++ b/video_formats/h264-mp4.json
@@ -2,7 +2,7 @@
     "main_pass":
     [
         "-n", "-c:v", "libx264",
-        "-pix_fmt", "yuv420p"
+        "-pix_fmt", "yuv420p10le"
     ],
      "extension": "mp4"
 }

--- a/video_formats/webm.json
+++ b/video_formats/webm.json
@@ -2,7 +2,7 @@
     "main_pass":
     [
         "-n",
-        "-pix_fmt", "yuv420p"
+        "-pix_fmt", "yuv422p12le"
     ],
      "extension": "webm"
 }


### PR DESCRIPTION
When using h264 and webm format to save video in linux, the video quality is poor. There are many strips in the video. After upgrading the video pix format, the strips were removed. 
The poor picture likes this.

![image](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/assets/144313702/0b62c439-b0b0-4ab8-b13b-4b431afe8276)
