### PR TITLE
Made save_metadata an optional parameter for now

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -55,6 +55,8 @@ class VideoCombine:
                 "pingpong": ("BOOLEAN", {"default": False}),
                 "save_image": ("BOOLEAN", {"default": True}),
                 "crf": ("INT", {"default": 20, "min": 0, "max": 100, "step": 1}),
+            },
+            "optional": {
                 "save_metadata": ("BOOLEAN", {"default": True}),
             },
             "hidden": {


### PR DESCRIPTION
ComfyUI gets a bit confused when loading old workflows that dont have the new parameter and the webpage is not reloaded, and making it optional keeps it from throwing errors. I image we can account for this with the .js code you have written up, but for now I'll just make it optional as an easy fix.