### PR TITLE
Added the ability to add audio from a path accepts wav or mp3

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -59,7 +59,7 @@ class VideoCombine:
             },
             "optional": {
                 "save_metadata": ("BOOLEAN", {"default": True}),
-                "audio_file": ("STRING", {"default": "/test/audio.wav"}),
+                "audio_file": ("STRING", {"default": ""}),
             },
             "hidden": {
                 "prompt": "PROMPT",

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -85,8 +85,7 @@ class VideoCombine:
         save_metadata=True,
         prompt=None,
         extra_pnginfo=None,
-        audio_file="",
-
+        audio_file=""
     ):
         # convert images to numpy
         frames: List[Image.Image] = []


### PR DESCRIPTION
I wanted to add the ability to add audio from a path, currently using the path module but maybe could be removed.  I use path to be more in align with unix verses paths.  If an audio path is added it will check if its a wav or mp3 file, then we convert the wav or mp3 to aac which the x264 and mp4 container accepts as input and mux that into a file.  We create a duplicate file but with the extension -audio.mp4 

```  # FFmpeg command with audio re-encoding
                mux_args = [ffmpeg_path, "-y", "-i", str(file_path), "-i", str(audio_file_path),
                            "-c:v", "copy", "-c:a", "aac", "-b:a", "192k", "-strict", "experimental", "-shortest", str(output_file_with_audio_path)]```

currently tested in my unix environment, needs windows testing, also may barf on spaces in file names which nobody likes ;) marked as experimental but worth adding.