### PR TITLE
Merge development branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The first of every `select_every_nth` input is passed and the remainder are disc
 ### Duplicate Batch
 
 ## Video Previews
-Load Video (Upload), Load Video (Path) and Video Combine provide animated previews.  
+Load Video (Upload), Load Video (Path), Load Images (Upload), Load Images (Path) and Video Combine provide animated previews.  
 Nodes with previews provide additional functionality when right clicked
 - Open preview
 - Save preview

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ComfyUI-VideoHelperSuite
 Nodes related to video workflows
 
-## Nodes
+## I/O Nodes
 ### Load Video
 Converts a video file into a series of images
 - video: The video file to be loaded
@@ -9,20 +9,21 @@ Converts a video file into a series of images
 - force_size: Allows for quick resizing to a number of suggested sizes. Several options allow you to set only width or height and determine the other from aspect ratio.
 - frame_load_cap: The maximum number of frames which will be returned. This could also be thought of as the maximum batch size.
 - skip_first_frames: How many frames to skip from the start of the video after adjusting for a forced frame rate. By incrementing this number by the frame_load_cap, you can easily process a longer input video in parts. 
-- select_every_nth: Allows for skipping a number of frames without considering the base frame rate or risking frame duplication.  
-A path variant of the Load Video node exists that allows loading videos from external paths, but does not currently support video previews
+- select_every_nth: Allows for skipping a number of frames without considering the base frame rate or risking frame duplication. Often useful when working with animated gifs
+A path variant of the Load Video node exists that allows loading videos from external paths
 ![step](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/assets/4284322/b5fc993c-5c9b-4608-afa4-48ae2e1380ef)
 ![resize](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/assets/4284322/98d2e78e-1c44-443c-a8fe-0dab0b5947f3)
-
+If [Advanced Previews](#advanced-previews) is enabled in the options menu of the web ui, the preview will reflect the current settings on the node.
 ### Load Image Sequence
 Loads all image files from a subfolder. Options are similar to Load Video.
 - image_load_cap: The maximum number of images which will be returned. This could also be thought of as the maximum batch size.
 - skip_first_images: How many images to skip. By incrementing this number by image_load_cap, you can easily divide a long sequence of images into multiple batches.
-- select_every_nth: Allows for skipping a number of images between every returned frame. As a set of image files doesn't have a frame rate, this is the only way to change the 'playback speed'
+- select_every_nth: Allows for skipping a number of images between every returned frame.
 
 A path variant of Load Image sequence also exists.
 ### Video Combine
-Combines a series of images into an output video
+Combines a series of images into an output video  
+If the optional audio input is provided, it will also be combined into the output video
 - frame_rate: How many of the input frames are displayed per second.  A higher frame rate means that the output video plays faster and has less duration. This should usually be kept to 8 for AnimateDiff, or matched to the force_rate of a Load Video node.
 - loop_count: How many additional times the video should repeat
 - filename_prefix: The base file name used for output.
@@ -30,17 +31,50 @@ Combines a series of images into an output video
   - Like the builtin Save Image node, you can add timestamps. `%date:yyyy-MM-ddThh:mm:ss%` might become 2023-10-31T6:45:25
 - format: The file format to use. Advanced information on configuring or adding additional video formats can be found in the [Video Formats](#video-formats) section.
 - pingpong: Causes the input to be played back in the reverse to create a clean loop.
-- save_image: Whether the image should be put into the output directory or the temp directory
+- save_image: Whether the image should be put into the output directory or the temp directory.
+ 
+Depending on the format chosen, additional options may become available, including
 - crf: Describes the quality of the output video. A lower number gives a higher quality video and a larger file size, while a higher number gives a lower quality video with a smaller size. Scaling varies by codec, but visually lossless output generally occurs around 20.
+- save_metadata: Includes a copy of the workflow in the ouput video which can be loaded by dragging and dropping the video, just like with images.
+- pix_fmt: Changes how the pixel data is stored. `yuv420p10le` has higher color quality, but won't work on all devices
+### Load Audio
+Provides a way to load standalone audio files.
+- seek_seconds: An optional start time for the audio file in seconds.
+
+## Latent/Image Nodes
+A number of utility nodes exist for managing latents. For each, there is an equivalent node which works on images.
+### Split Batch
+Divides the latents into two sets. The first `split_index` latents go to ouput A and the remainder to output B. If less then `split_index` latents are provided as input, all are passed to output A and output B is empty.
+### Merge Batch
+Combines two groups of latents into a single output. The order of the output is the latents in A followed by the latents in B.  
+If the input groups are not the same size, the node provides options for rescaling the latents before merging.
+### Select Every Nth
+The first of every `select_every_nth` input is passed and the remainder are discarded
+### Get Count
+### Duplicate Batch
 
 ## Video Previews
-Load Video (Upload) and Video Combine provide animated previews, and this functionality may be added to additional nodes in the future.  
+Load Video (Upload), Load Video (Path) and Video Combine provide animated previews.  
 Nodes with previews provide additional functionality when right clicked
 - Open preview
 - Save preview
 - Pause preview: Can improve performance with very large videos
-- Hide preview: Can improve performance, save space, and also works with animated images
+- Hide preview: Can improve performance, save space
 - Sync preview: Restarts all previews for side-by-side comparisons
+
+### Advanced Previews
+Advanced Previews must be manually enabled by clicking the settings gear next to Queue Prompt and checking the box for VHS Advanced Previews.  
+If enabled, videos which are displayed in the ui will be converted with ffmpeg on request. This has several benefits
+- Previews for Load Video nodes will reflect the settings on the node such as skip_first_frames and frame_load_cap
+  - This makes it easy to select an exact portion of an input video and sync it with outputs
+- It can use substantially less bandwidth if running the server remotely
+- It can greatly improve the browser performance by downsizing videos to the in ui resolution, particularly useful with animated gifs
+- It allows for previews of videos that would not normally be playable in browser.
+- It allows previews to be displayed for videos in external folders when `VHS_UNSAFE_PATHS` is set as an environment variable.
+
+This fucntionality is disabled since it comes with several downsides
+- There is a delay before videos show in the browser. This delay can become quite large if the input video is long
+- The preview videos are lower quality (The original can always be viewed with Right Click -> Open preview)
 
 ## Video Formats
 Those familiar with ffmpeg are able to add json files to the video_formats folders to add new output types to Video Combine. 
@@ -50,17 +84,26 @@ Consider the following example for av1-webm
     "main_pass":
     [
         "-n", "-c:v", "libsvtav1",
-        "-pix_fmt", "yuv420p10le"
+        "-pix_fmt", "yuv420p10le",
+        "-crf", ["crf","INT", {"default": 23, "min": 0, "max": 100, "step": 1}]
     ],
+    "audio_pass": ["-c:a", "libopus"],
      "extension": "webm",
      "environment": {"SVT_LOG": "1"}
 }
 ```
-Most configuration takes place in `main_pass`, which is a list of arguements that are passed to ffmpeg. 
+Most configuration takes place in `main_pass`, which is a list of arguments that are passed to ffmpeg. 
 - `"-n"` designates that the command should fail if a file of the same name already exists. This should never happen, but if some bug were to occur, it would ensure other files aren't overwritten.
 - `"-c:v", "libsvtav1"` designates that the video should be encoded with an av1 codec using the new SVT-AV1 encoder. SVT-AV1 is much faster than libaom-av1, but may not exist in older versions of ffmpeg. Alternatively, av1_nvenc could be used for gpu encoding with newer nvidia cards. 
-- `"-pix_fmt", "yuv420p10le"` designates the standard pixel format with 10-bit color. It's important that some pixel format be specified to ensure a nonconfigurable input pix_fmt isn't used. 
+- `"-pix_fmt", "yuv420p10le"` designates the standard pixel format with 10-bit color. It's important that some pixel format be specified to ensure a nonconfigurable input pix_fmt isn't used.
 
+`audio pass` contains a list of arguments which are passed to ffmpeg when audio is passed into Video Combine
 
 `extension` designates both the file extension and the container format that is used. If some of the above options are omitted from `main_pass` it can affect what default options are chosen.  
-`environment` can optionally be provided to set environment variables during execution. For av1 it's used to reduce the verbosity of logging so that only major errors are displayed.
+`environment` can optionally be provided to set environment variables during execution. For av1 it's used to reduce the verbosity of logging so that only major errors are displayed.  
+`input_color_depth` effects the format in which pixels are passed to the ffmpeg subprocess. Current valid options are `8bit` and `16bit`. The later will produce higher quality output, but is experimental.
+
+Fields can be exposed in the webui as a widget using a format similar to what is used in the creation of custom nodes. In the above example, the argument for `-crf` will be exposed as a format widget in the webui. Format widgets are a list of up to 3 terms
+- The name of the widget that will be displayed in the web ui
+- Either a primitive such as "INT" or "BOOLEAN", or a list of string options
+- A dictionary of options

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ If the optional audio input is provided, it will also be combined into the outpu
   - Like the builtin Save Image node, you can add timestamps. `%date:yyyy-MM-ddThh:mm:ss%` might become 2023-10-31T6:45:25
 - format: The file format to use. Advanced information on configuring or adding additional video formats can be found in the [Video Formats](#video-formats) section.
 - pingpong: Causes the input to be played back in the reverse to create a clean loop.
-- save_image: Whether the image should be put into the output directory or the temp directory.
+- save_output: Whether the image should be put into the output directory or the temp directory.
+Returns: a `VHS_FILENAMES` which consists of a boolean indicating if save_output is enabled and a list of the full filepaths of all generated outputs in the order created. Accordingly `output[1][-1]` will be the most complete output.
  
 Depending on the format chosen, additional options may become available, including
 - crf: Describes the quality of the output video. A lower number gives a higher quality video and a larger file size, while a higher number gives a lower quality video with a smaller size. Scaling varies by codec, but visually lossless output generally occurs around 20.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If enabled, videos which are displayed in the ui will be converted with ffmpeg o
 - It can use substantially less bandwidth if running the server remotely
 - It can greatly improve the browser performance by downsizing videos to the in ui resolution, particularly useful with animated gifs
 - It allows for previews of videos that would not normally be playable in browser.
-- It allows previews to be displayed for videos in external folders when `VHS_UNSAFE_PATHS` is set as an environment variable.
+- Can be limited to subdirectories of ComyUI if `VHS_STRICT_PATHS` is set as an environment variable.
 
 This fucntionality is disabled since it comes with several downsides
 - There is a delay before videos show in the browser. This delay can become quite large if the input video is long

--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
 # ComfyUI-VideoHelperSuite
 Nodes related to video workflows
+
+## Nodes
+### Load Video
+Converts a video file into a series of images
+- video: The video file to be loaded
+- force_rate: Discards or duplicates frames as needed to hit a target frame rate. Disabled by setting to 0. This can be used to quickly match a suggested frame rate like the 8 fps of AnimateDiff.
+- force_size: Allows for quick resizing to a number of suggested sizes. Several options allow you to set only width or height and determine the other from aspect ratio.
+- frame_load_cap: The maximum number of frames which will be returned. This could also be thought of as the maximum batch size.
+- skip_first_frames: How many frames to skip from the start of the video after adjusting for a forced frame rate. By incrementing this number by the frame_load_cap, you can easily process a longer input video in parts. 
+- select_every_nth: Allows for skipping a number of frames without considering the base frame rate or risking frame duplication.  
+A path variant of the Load Video node exists that allows loading videos from external paths, but does not currently support video previews
+![step](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/assets/4284322/b5fc993c-5c9b-4608-afa4-48ae2e1380ef)
+![resize](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/assets/4284322/98d2e78e-1c44-443c-a8fe-0dab0b5947f3)
+
+### Load Image Sequence
+Loads all image files from a subfolder. Options are similar to Load Video.
+- image_load_cap: The maximum number of images which will be returned. This could also be thought of as the maximum batch size.
+- skip_first_images: How many images to skip. By incrementing this number by image_load_cap, you can easily divide a long sequence of images into multiple batches.
+- select_every_nth: Allows for skipping a number of images between every returned frame. As a set of image files doesn't have a frame rate, this is the only way to change the 'playback speed'
+
+A path variant of Load Image sequence also exists.
+### Video Combine
+Combines a series of images into an output video
+- frame_rate: How many of the input frames are displayed per second.  A higher frame rate means that the output video plays faster and has less duration. This should usually be kept to 8 for AnimateDiff, or matched to the force_rate of a Load Video node.
+- loop_count: How many additional times the video should repeat
+- filename_prefix: The base file name used for output.
+  - You can save output to a subfolder: `subfolder/video`
+  - Like the builtin Save Image node, you can add timestamps. `%date:yyyy-MM-ddThh:mm:ss%` might become 2023-10-31T6:45:25
+- format: The file format to use. Advanced information on configuring or adding additional video formats can be found in the [Video Formats](#video-formats) section.
+- pingpong: Causes the input to be played back in the reverse to create a clean loop.
+- save_image: Whether the image should be put into the output directory or the temp directory
+- crf: Describes the quality of the output video. A lower number gives a higher quality video and a larger file size, while a higher number gives a lower quality video with a smaller size. Scaling varies by codec, but visually lossless output generally occurs around 20.
+
+## Video Previews
+Load Video (Upload) and Video Combine provide animated previews, and this functionality may be added to additional nodes in the future.  
+Nodes with previews provide additional functionality when right clicked
+- Open preview
+- Save preview
+- Pause preview: Can improve performance with very large videos
+- Hide preview: Can improve performance, save space, and also works with animated images
+- Sync preview: Restarts all previews for side-by-side comparisons
+
+## Video Formats
+Those familiar with ffmpeg are able to add json files to the video_formats folders to add new output types to Video Combine. 
+Consider the following example for av1-webm
+```json
+{
+    "main_pass":
+    [
+        "-n", "-c:v", "libsvtav1",
+        "-pix_fmt", "yuv420p10le"
+    ],
+     "extension": "webm",
+     "environment": {"SVT_LOG": "1"}
+}
+```
+Most configuration takes place in `main_pass`, which is a list of arguements that are passed to ffmpeg. 
+- `"-n"` designates that the command should fail if a file of the same name already exists. This should never happen, but if some bug were to occur, it would ensure other files aren't overwritten.
+- `"-c:v", "libsvtav1"` designates that the video should be encoded with an av1 codec using the new SVT-AV1 encoder. SVT-AV1 is much faster than libaom-av1, but may not exist in older versions of ffmpeg. Alternatively, av1_nvenc could be used for gpu encoding with newer nvidia cards. 
+- `"-pix_fmt", "yuv420p10le"` designates the standard pixel format with 10-bit color. It's important that some pixel format be specified to ensure a nonconfigurable input pix_fmt isn't used. 
+
+
+`extension` designates both the file extension and the container format that is used. If some of the above options are omitted from `main_pass` it can affect what default options are chosen.  
+`environment` can optionally be provided to set environment variables during execution. For av1 it's used to reduce the verbosity of logging so that only major errors are displayed.

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,6 @@
 from .videohelpersuite.nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 import folder_paths
+from .videohelpersuite.server import server
 
 WEB_DIRECTORY = "./web"
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]

--- a/video_formats/ProRes.json
+++ b/video_formats/ProRes.json
@@ -5,5 +5,6 @@
         "-profile:v","3",
         "-pix_fmt", "yuv422p10"
     ],
-     "extension": "mov"
+    "audio_pass": ["-c:a", "pcm_s16le"],
+    "extension": "mov"
 }

--- a/video_formats/av1-webm.json
+++ b/video_formats/av1-webm.json
@@ -4,6 +4,7 @@
         "-n", "-c:v", "libsvtav1",
         "-pix_fmt", "yuv420p10le"
     ],
-     "extension": "webm",
-     "environment": {"SVT_LOG": "1"}
+    "audio_pass": ["-c:a", "libopus"],
+    "extension": "webm",
+    "environment": {"SVT_LOG": "1"}
 }

--- a/video_formats/av1-webm.json
+++ b/video_formats/av1-webm.json
@@ -7,7 +7,7 @@
     ],
     "audio_pass": ["-c:a", "libopus"],
     "input_color_depth": ["input_color_depth", ["8bit", "16bit"]],
-    "save_metadata": ["save_metadata", ["comment", "False"]],
+    "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],
     "extension": "webm",
     "environment": {"SVT_LOG": "1"}
 }

--- a/video_formats/av1-webm.json
+++ b/video_formats/av1-webm.json
@@ -2,7 +2,8 @@
     "main_pass":
     [
         "-n", "-c:v", "libsvtav1",
-        "-pix_fmt", "yuv420p10le"
+        "-pix_fmt", ["pix_fmt", ["yuv420p10le", "yuv420p"]],
+        "-crf", ["crf","INT", {"default": 23, "min": 0, "max": 100, "step": 1}]
     ],
     "audio_pass": ["-c:a", "libopus"],
     "extension": "webm",

--- a/video_formats/av1-webm.json
+++ b/video_formats/av1-webm.json
@@ -6,6 +6,8 @@
         "-crf", ["crf","INT", {"default": 23, "min": 0, "max": 100, "step": 1}]
     ],
     "audio_pass": ["-c:a", "libopus"],
+    "input_color_depth": ["input_color_depth", ["8bit", "16bit"]],
+    "save_metadata": ["save_metadata", ["comment", "False"]],
     "extension": "webm",
     "environment": {"SVT_LOG": "1"}
 }

--- a/video_formats/h264-mp4.json
+++ b/video_formats/h264-mp4.json
@@ -6,6 +6,6 @@
         "-crf", ["crf","INT", {"default": 19, "min": 0, "max": 100, "step": 1}]
     ],
     "audio_pass": ["-c:a", "aac"],
-    "save_metadata": ["save_metadata", ["comment", "False"]],
+    "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],
     "extension": "mp4"
 }

--- a/video_formats/h264-mp4.json
+++ b/video_formats/h264-mp4.json
@@ -2,7 +2,8 @@
     "main_pass":
     [
         "-n", "-c:v", "libx264",
-        "-pix_fmt", "yuv420p"
+        "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le"]],
+        "-crf", ["crf","INT", {"default": 19, "min": 0, "max": 100, "step": 1}]
     ],
     "audio_pass": ["-c:a", "aac"],
     "extension": "mp4"

--- a/video_formats/h264-mp4.json
+++ b/video_formats/h264-mp4.json
@@ -4,5 +4,6 @@
         "-n", "-c:v", "libx264",
         "-pix_fmt", "yuv420p"
     ],
-     "extension": "mp4"
+    "audio_pass": ["-c:a", "aac"],
+    "extension": "mp4"
 }

--- a/video_formats/h264-mp4.json
+++ b/video_formats/h264-mp4.json
@@ -6,5 +6,6 @@
         "-crf", ["crf","INT", {"default": 19, "min": 0, "max": 100, "step": 1}]
     ],
     "audio_pass": ["-c:a", "aac"],
+    "save_metadata": ["save_metadata", ["comment", "False"]],
     "extension": "mp4"
 }

--- a/video_formats/h265-mp4.json
+++ b/video_formats/h265-mp4.json
@@ -2,7 +2,8 @@
     "main_pass":
     [
         "-n", "-c:v", "libx265",
-        "-pix_fmt", "yuv420p10le",
+        "-pix_fmt", ["pix_fmt", ["yuv420p10le", "yuv420p"]],
+        "-crf", ["crf","INT", {"default": 22, "min": 0, "max": 100, "step": 1}],
         "-preset", "medium",
         "-x265-params", "log-level=quiet"
     ],

--- a/video_formats/h265-mp4.json
+++ b/video_formats/h265-mp4.json
@@ -8,5 +8,6 @@
         "-x265-params", "log-level=quiet"
     ],
     "audio_pass": ["-c:a", "aac"],
+    "save_metadata": ["save_metadata", ["comment", "False"]],
     "extension": "mp4"
 }

--- a/video_formats/h265-mp4.json
+++ b/video_formats/h265-mp4.json
@@ -8,6 +8,6 @@
         "-x265-params", "log-level=quiet"
     ],
     "audio_pass": ["-c:a", "aac"],
-    "save_metadata": ["save_metadata", ["comment", "False"]],
+    "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],
     "extension": "mp4"
 }

--- a/video_formats/h265-mp4.json
+++ b/video_formats/h265-mp4.json
@@ -6,5 +6,6 @@
         "-preset", "medium",
         "-x265-params", "log-level=quiet"
     ],
-     "extension": "mp4"
+    "audio_pass": ["-c:a", "aac"],
+    "extension": "mp4"
 }

--- a/video_formats/webm.json
+++ b/video_formats/webm.json
@@ -3,7 +3,8 @@
     [
         "-n",
         "-pix_fmt", "yuv420p",
-        "-crf", ["crf","INT", {"default": 20, "min": 0, "max": 100, "step": 1}]
+        "-crf", ["crf","INT", {"default": 20, "min": 0, "max": 100, "step": 1}],
+        "-b:v", "0"
     ],
     "audio_pass": ["-c:a", "libvorbis"],
     "save_metadata": ["save_metadata", ["comment", "False"]],

--- a/video_formats/webm.json
+++ b/video_formats/webm.json
@@ -6,5 +6,6 @@
         "-crf", ["crf","INT", {"default": 20, "min": 0, "max": 100, "step": 1}]
     ],
     "audio_pass": ["-c:a", "libvorbis"],
+    "save_metadata": ["save_metadata", ["comment", "False"]],
     "extension": "webm"
 }

--- a/video_formats/webm.json
+++ b/video_formats/webm.json
@@ -7,6 +7,6 @@
         "-b:v", "0"
     ],
     "audio_pass": ["-c:a", "libvorbis"],
-    "save_metadata": ["save_metadata", ["comment", "False"]],
+    "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],
     "extension": "webm"
 }

--- a/video_formats/webm.json
+++ b/video_formats/webm.json
@@ -4,5 +4,6 @@
         "-n",
         "-pix_fmt", "yuv420p"
     ],
-     "extension": "webm"
+    "audio_pass": ["-c:a", "libvorbis"],
+    "extension": "webm"
 }

--- a/video_formats/webm.json
+++ b/video_formats/webm.json
@@ -2,7 +2,8 @@
     "main_pass":
     [
         "-n",
-        "-pix_fmt", "yuv420p"
+        "-pix_fmt", "yuv420p",
+        "-crf", ["crf","INT", {"default": 20, "min": 0, "max": 100, "step": 1}]
     ],
     "audio_pass": ["-c:a", "libvorbis"],
     "extension": "webm"

--- a/videohelpersuite/load_images_nodes.py
+++ b/videohelpersuite/load_images_nodes.py
@@ -15,7 +15,8 @@ def is_changed_load_images(directory: str, image_load_cap: int = 0, skip_first_i
             return False
         
     dir_files = get_sorted_dir_files_from_directory(directory, skip_first_images, select_every_nth, FolderOfImages.IMG_EXTENSIONS)
-    dir_files = dir_files[:image_load_cap]
+    if image_load_cap != 0:
+        dir_files = dir_files[:image_load_cap]
 
     m = hashlib.sha256()
     for filepath in dir_files:

--- a/videohelpersuite/load_images_nodes.py
+++ b/videohelpersuite/load_images_nodes.py
@@ -123,7 +123,7 @@ class LoadImagesFromDirectoryPath:
     def INPUT_TYPES(s):
         return {
             "required": {
-                "directory": ("VHSPATH", {"default": "X://path/to/images", "extensiosn": []}),
+                "directory": ("VHSPATH", {"default": "X://path/to/images", "extensions": []}),
             },
             "optional": {
                 "image_load_cap": ("INT", {"default": 0, "min": 0, "step": 1}),

--- a/videohelpersuite/load_images_nodes.py
+++ b/videohelpersuite/load_images_nodes.py
@@ -34,7 +34,6 @@ def validate_load_images(directory: str, **kwargs):
 
 
 def load_images(directory: str, image_load_cap: int = 0, skip_first_images: int = 0, select_every_nth: int = 1):
-    directory = folder_paths.get_annotated_filepath(directory.strip())
     if not os.path.isdir(directory):
         raise FileNotFoundError(f"Directory '{directory} cannot be found.")
 
@@ -50,6 +49,8 @@ def load_images(directory: str, image_load_cap: int = 0, skip_first_images: int 
     if image_load_cap > 0:
         limit_images = True
     image_count = 0
+    loaded_alpha = False
+    zero_mask = torch.zeros((64,64), dtype=torch.float32, device="cpu")
 
     for image_path in dir_files:
         if limit_images and image_count >= image_load_cap:
@@ -62,8 +63,12 @@ def load_images(directory: str, image_load_cap: int = 0, skip_first_images: int 
         if 'A' in i.getbands():
             mask = np.array(i.getchannel('A')).astype(np.float32) / 255.0
             mask = 1. - torch.from_numpy(mask)
+            if not loaded_alpha:
+                loaded_alpha = True
+                zero_mask = torch.zeros((len(image[0]),len(image[0][0])), dtype=torch.float32, device="cpu")
+                masks = [zero_mask] * image_count
         else:
-            mask = torch.zeros((64,64), dtype=torch.float32, device="cpu")
+            mask = zero_mask
         images.append(image)
         masks.append(mask)
         image_count += 1
@@ -118,7 +123,7 @@ class LoadImagesFromDirectoryPath:
     def INPUT_TYPES(s):
         return {
             "required": {
-                "directory": ("STRING", {"default": "X://path/to/images"}),
+                "directory": ("VHSPATH", {"default": "X://path/to/images", "extensiosn": []}),
             },
             "optional": {
                 "image_load_cap": ("INT", {"default": 0, "min": 0, "step": 1}),

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -7,7 +7,7 @@ import cv2
 import folder_paths
 from comfy.utils import common_upscale
 from .logger import logger
-from .utils import calculate_file_hash, get_sorted_dir_files_from_directory, get_audio, lazy_eval
+from .utils import calculate_file_hash, get_sorted_dir_files_from_directory, get_audio, lazy_eval, is_url
 
 
 video_extensions = ['webm', 'mp4', 'mkv', 'gif']
@@ -175,10 +175,16 @@ class LoadVideoPath:
 
     @classmethod
     def IS_CHANGED(s, video, **kwargs):
+        if is_url(video):
+            #Fetching a remote video heavy, so hash check is skipped
+            return 1
         return calculate_file_hash(video.strip("\""))
 
     @classmethod
     def VALIDATE_INPUTS(s, video, **kwargs):
+        if is_url(video):
+            #Probably not feasible to check if url resolves here
+            return True
         if not os.path.isfile(video.strip("\"")):
             return "Invalid video file: {}".format(video)
         return True

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -34,9 +34,8 @@ def target_size(width, height, force_size) -> tuple[int, int]:
         return (width, height)
 
 def load_video_cv(video: str, force_rate: int, force_size: str, frame_load_cap: int, skip_first_frames: int, select_every_nth: int):
-    filename = folder_paths.get_annotated_filepath(video.strip("\""))
     try:
-        video_cap = cv2.VideoCapture(filename)
+        video_cap = cv2.VideoCapture(video)
         if not video_cap.isOpened():
             raise ValueError(f"{video} could not be loaded with cv.")
         # set video_cap to look at start_index frame

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -33,7 +33,7 @@ def target_size(width, height, force_size) -> tuple[int, int]:
             width = int(force_size[0])
         else:
             width = int(force_size[0])
-            height = int(force_size[0])
+            height = int(force_size[1])
     return (width, height)
 
 def load_video_cv(video: str, force_rate: int, force_size: str, frame_load_cap: int, skip_first_frames: int, select_every_nth: int):
@@ -118,7 +118,7 @@ class LoadVideoUpload:
                 if len(file_parts) > 1 and (file_parts[-1] in video_extensions):
                     files.append(f)
         return {"required": {
-                    "video": (sorted(files), {"video_upload": True}),
+                    "video": (sorted(files),),
                      "force_rate": ("INT", {"default": 0, "min": 0, "max": 24, "step": 1}),
                      "force_size": (["Disabled", "256x?", "?x256", "256x256", "512x?", "?x512", "512x512"],),
                      "frame_load_cap": ("INT", {"default": 0, "min": 0, "step": 1}),

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -128,8 +128,8 @@ class LoadVideoUpload:
 
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
 
-    RETURN_TYPES = ("IMAGE", "INT", "AUDIO", )
-    RETURN_NAMES = ("IMAGE", "frame_count", "AUDIO",)
+    RETURN_TYPES = ("IMAGE", "INT", "VHS_AUDIO", )
+    RETURN_NAMES = ("IMAGE", "frame_count", "audio",)
     FUNCTION = "load_video"
 
     known_exceptions = []
@@ -165,8 +165,8 @@ class LoadVideoPath:
 
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
 
-    RETURN_TYPES = ("IMAGE", "INT", "AUDIO", )
-    RETURN_NAMES = ("IMAGE", "frame_count", "AUDIO",)
+    RETURN_TYPES = ("IMAGE", "INT", "VHS_AUDIO", )
+    RETURN_NAMES = ("IMAGE", "frame_count", "audio",)
     FUNCTION = "load_video"
 
     known_exceptions = []

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -133,6 +133,7 @@ class LoadVideoUpload:
     known_exceptions = []
     def load_video(self, **kwargs):
         try:
+            kwargs['video'] = folder_paths.get_annotated_filepath(kwargs['video'].strip("\""))
             return load_video_cv(**kwargs)
         except Exception as e:
             raise RuntimeError(f"Failed to load video: {kwargs['video']}\ndue to: {e.__str__()}")
@@ -154,7 +155,7 @@ class LoadVideoPath:
     def INPUT_TYPES(s):
         return {
             "required": {
-                "video": ("STRING", {"default": "X://insert/path/here.mp4"}),
+                "video": ("VHSPATH", {"default": "X://insert/path/here.mp4", "extensions": video_extensions}),
                 "force_rate": ("INT", {"default": 0, "min": 0, "max": 24, "step": 1}),
                 "force_size": (["Disabled", "256x?", "?x256", "256x256", "512x?", "?x512", "512x512"],),
                 "frame_load_cap": ("INT", {"default": 0, "min": 0, "step": 1}),

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import numpy as np
 import torch
 from PIL import Image, ImageOps
@@ -7,7 +8,7 @@ import cv2
 import folder_paths
 from comfy.utils import common_upscale
 from .logger import logger
-from .utils import calculate_file_hash, get_sorted_dir_files_from_directory
+from .utils import calculate_file_hash, get_sorted_dir_files_from_directory, ffmpeg_path
 
 
 video_extensions = ['webm', 'mp4', 'mkv', 'gif']
@@ -33,11 +34,19 @@ def target_size(width, height, force_size) -> tuple[int, int]:
                 width = int(force_size[0])
         return (width, height)
 
-
+def get_audio(start_time, duration, file):
+    args = [ffmpeg_path, "-v", "error", "-i", file]
+    if start_time > 0:
+        args += ["-ss", str(start_time)]
+    if duration > 0:
+        args += ["-t", str(duration)]
+    return subprocess.run(args + ["-f", "wav", "-"],
+                          stdout=subprocess.PIPE, check=True).stdout
 
 def load_video_cv(video: str, force_rate: int, force_size: str, frame_load_cap: int, skip_first_frames: int, select_every_nth: int):
+    filename = folder_paths.get_annotated_filepath(video.strip("\""))
     try:
-        video_cap = cv2.VideoCapture(folder_paths.get_annotated_filepath(video.strip("\"")))
+        video_cap = cv2.VideoCapture(filename)
         if not video_cap.isOpened():
             raise ValueError(f"{video} could not be loaded with cv.")
         # set video_cap to look at start_index frame
@@ -99,7 +108,10 @@ def load_video_cv(video: str, force_rate: int, force_size: str, frame_load_cap: 
             s = common_upscale(s, new_size[0], new_size[1], "lanczos", "disabled")
             images = s.movedim(1,-1)
     # TODO: raise an error maybe if no frames were loaded?
-    return (images, frames_added)
+
+    #Setup lambda for lazy audio capture
+    audio = lambda : get_audio(skip_first_frames * target_frame_time, frame_load_cap*target_frame_time, filename)
+    return (images, frames_added, audio)
 
 
 class LoadVideoUpload:
@@ -123,8 +135,8 @@ class LoadVideoUpload:
 
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
 
-    RETURN_TYPES = ("IMAGE", "INT",)
-    RETURN_NAMES = ("IMAGE", "frame_count",)
+    RETURN_TYPES = ("IMAGE", "INT", "AUDIO", )
+    RETURN_NAMES = ("IMAGE", "frame_count", "AUDIO",)
     FUNCTION = "load_video"
 
     known_exceptions = []
@@ -162,8 +174,8 @@ class LoadVideoPath:
 
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
 
-    RETURN_TYPES = ("IMAGE", "INT",)
-    RETURN_NAMES = ("IMAGE", "frame_count",)
+    RETURN_TYPES = ("IMAGE", "INT", "AUDIO", )
+    RETURN_NAMES = ("IMAGE", "frame_count", "AUDIO",)
     FUNCTION = "load_video"
 
     known_exceptions = []

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -234,7 +234,7 @@ class VideoCombine:
                 metadata = metadata.replace("#","\\#")
                 metadata = metadata.replace("=","\\=")
                 metadata = metadata.replace("\n","\\\n")
-                metadata = video_format['save_metadata']+ "=" + metadata
+                metadata = "comment=" + metadata
                 with open(metadata_path, "w") as f:
                     f.write(";FFMETADATA1\n")
                     f.write(metadata)
@@ -287,6 +287,9 @@ class VideoCombine:
                 if res.stderr:
                     print(res.stderr.decode("utf-8"), end="", file=sys.stderr)
                 output_files.append(output_file_with_audio)
+                #Return this file with audio to the webui.
+                #It will be muted unless opened or saved with right click
+                file = output_file_with_audio
 
         previews = [
             {

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -290,17 +290,18 @@ class LoadAudio:
         #Hide ffmpeg formats if ffmpeg isn't available
         return {
             "required": {
-                "audio_file": ("STRING", {"default": ""}),
-                }
+                "audio_file": ("VHSPATH", {"default": "input/", "extensions": ['wav','mp3','ogg','m4a','flac']}),
+                },
+            "optional" : {"seek_seconds": ("FLOAT", {"default": 0, "min": 0})}
         }
 
     RETURN_TYPES = ("AUDIO",)
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
     FUNCTION = "load_audio"
-    def load_audio(self, audio_file):
+    def load_audio(self, audio_file, seek_seconds):
         #Eagerly fetch the audio since the user must be using it if the
         #node executes, unlike Load Video
-        audio = get_audio(audio_file)
+        audio = get_audio(audio_file, start_time=seek_seconds)
         return (lambda : audio,)
 
     @classmethod

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -174,7 +174,7 @@ class VideoCombine:
             pnginfo=metadata,
             compress_level=4,
         )
-        output_files.append(file)
+        output_files.append(file_path)
 
         format_type, format_ext = format.split("/")
         if format_type == "image":
@@ -194,7 +194,7 @@ class VideoCombine:
                 loop=loop_count,
                 compress_level=4,
             )
-            output_files.append(file)
+            output_files.append(file_path)
         else:
             # Use ffmpeg to save a video
             if ffmpeg_path is None:
@@ -263,10 +263,10 @@ class VideoCombine:
                             + e.stderr.decode("utf-8"))
             if res.stderr:
                 print(res.stderr.decode("utf-8"), end="", file=sys.stderr)
-            output_files.append(file)
+            output_files.append(file_path)
 
 
-            # Audio Injection ater video is created, saves additional video with -audio.mp4
+            # Audio Injection after video is created, saves additional video with -audio.mp4
 
             # Create audio file if input was provided
             if audio:
@@ -293,7 +293,7 @@ class VideoCombine:
                             + e.stderr.decode("utf-8"))
                 if res.stderr:
                     print(res.stderr.decode("utf-8"), end="", file=sys.stderr)
-                output_files.append(output_file_with_audio)
+                output_files.append(output_file_with_audio_path)
                 #Return this file with audio to the webui.
                 #It will be muted unless opened or saved with right click
                 file = output_file_with_audio
@@ -306,7 +306,7 @@ class VideoCombine:
                 "format": format,
             }
         ]
-        return {"ui": {"gifs": previews}, "result": (output_files,)}
+        return {"ui": {"gifs": previews}, "result": ((save_output, output_files),)}
     @classmethod
     def VALIDATE_INPUTS(self, **kwargs):
         return True

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -139,6 +139,7 @@ class VideoCombine:
             subfolder,
             _,
         ) = folder_paths.get_save_image_path(filename_prefix, output_dir)
+        output_files = []
 
         metadata = PngInfo()
         video_metadata = {}
@@ -176,6 +177,7 @@ class VideoCombine:
             pnginfo=metadata,
             compress_level=4,
         )
+        output_files.append(file)
 
         format_type, format_ext = format.split("/")
         if format_type == "image":
@@ -195,6 +197,7 @@ class VideoCombine:
                 loop=loop_count,
                 compress_level=4,
             )
+            output_files.append(file)
         else:
             # Use ffmpeg to save a video
             if ffmpeg_path is None:
@@ -256,6 +259,7 @@ class VideoCombine:
                             + e.stderr.decode("utf-8"))
             if res.stderr:
                 print(res.stderr.decode("utf-8"), end="", file=sys.stderr)
+            output_files.append(file)
 
 
             # Audio Injection ater video is created, saves additional video with -audio.mp4
@@ -276,7 +280,6 @@ class VideoCombine:
                             "-i", "-", "-c:v", "copy"] \
                             + video_format["audio_pass"] \
                             + ["-af", "apad", "-shortest", output_file_with_audio_path]
-                            #"-c:a", "libopus", "-b:a", "192k", "-strict", "experimental",
 
                 try:
                     res = subprocess.run(mux_args, input=audio(), env=env,
@@ -286,6 +289,7 @@ class VideoCombine:
                             + e.stderr.decode("utf-8"))
                 if res.stderr:
                     print(res.stderr.decode("utf-8"), end="", file=sys.stderr)
+                output_files.append(output_file_with_audio)
 
         previews = [
             {
@@ -295,7 +299,7 @@ class VideoCombine:
                 "format": format,
             }
         ]
-        return {"ui": {"gifs": previews}}
+        return {"ui": {"gifs": previews}, "result": output_files}
     @classmethod
     def VALIDATE_INPUTS(self, **kwargs):
         return True

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -23,10 +23,6 @@ folder_paths.folder_names_and_paths["video_formats"] = (
     [".json"]
 )
 
-preferred_backend = "opencv"
-if "VHS_PREFERRED_BACKEND" in os.environ:
-    preferred_backend = os.environ['VHS_PREFERRED_BACKEND']
-
 def gen_format_widgets(video_format):
     for k in video_format:
         if k.endswith("_pass"):
@@ -104,7 +100,8 @@ class VideoCombine:
             },
         }
 
-    RETURN_TYPES = ("GIF",)
+    RETURN_TYPES = ("VHS_FILENAMES",)
+    RETURN_NAMES = ("Filenames",)
     OUTPUT_NODE = True
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
     FUNCTION = "combine_video"
@@ -299,7 +296,7 @@ class VideoCombine:
                 "format": format,
             }
         ]
-        return {"ui": {"gifs": previews}, "result": output_files}
+        return {"ui": {"gifs": previews}, "result": (output_files,)}
     @classmethod
     def VALIDATE_INPUTS(self, **kwargs):
         return True
@@ -335,14 +332,13 @@ class LoadAudio:
         #TODO: Perform simple check for audio formats?
         return True
 
-
-
 NODE_CLASS_MAPPINGS = {
     "VHS_VideoCombine": VideoCombine,
     "VHS_LoadVideo": LoadVideoUpload,
     "VHS_LoadVideoPath": LoadVideoPath,
     "VHS_LoadImages": LoadImagesFromDirectoryUpload,
     "VHS_LoadImagesPath": LoadImagesFromDirectoryPath,
+    "VHS_LoadAudio": LoadAudio,
     # Latent and Image nodes
     "VHS_SplitLatents": SplitLatents,
     "VHS_SplitImages": SplitImages,
@@ -354,7 +350,6 @@ NODE_CLASS_MAPPINGS = {
     "VHS_GetImageCount": GetImageCount,
     "VHS_DuplicateLatents": DuplicateLatents,
     "VHS_DuplicateImages": DuplicateImages,
-    "VHS_LoadAudio": LoadAudio,
 }
 NODE_DISPLAY_NAME_MAPPINGS = {
     "VHS_VideoCombine": "Video Combine 🎥🅥🅗🅢",
@@ -362,6 +357,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "VHS_LoadVideoPath": "Load Video (Path) 🎥🅥🅗🅢",
     "VHS_LoadImages": "Load Images (Upload) 🎥🅥🅗🅢",
     "VHS_LoadImagesPath": "Load Images (Path) 🎥🅥🅗🅢",
+    "VHS_LoadAudio": "Load Audio (Path)🎥🅥🅗🅢",
     # Latent and Image nodes
     "VHS_SplitLatents": "Split Latent Batch 🎥🅥🅗🅢",
     "VHS_SplitImages": "Split Image Batch 🎥🅥🅗🅢",
@@ -373,5 +369,4 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "VHS_GetImageCount": "Get Image Count 🎥🅥🅗🅢",
     "VHS_DuplicateLatents": "Duplicate Latent Batch 🎥🅥🅗🅢",
     "VHS_DuplicateImages": "Duplicate Image Batch 🎥🅥🅗🅢",
-    "VHS_LoadAudio": "Load Audio (Path)🎥🅥🅗🅢",
 }

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -154,7 +154,7 @@ class VideoCombine:
         max_counter = 0
 
         # Loop through the existing files
-        matcher = re.compile(f"{re.escape(filename)}_(\d+)_?\.[a-zA-Z0-9]+")
+        matcher = re.compile(f"{re.escape(filename)}_(\d+)\D*\.[a-zA-Z0-9]+")
         for existing_file in os.listdir(full_output_folder):
             # Check if the file matches the expected format
             match = matcher.fullmatch(existing_file)
@@ -179,6 +179,8 @@ class VideoCombine:
 
         format_type, format_ext = format.split("/")
         if format_type == "image":
+            file = f"{filename}_{counter:05}.{format_ext}"
+            file_path = os.path.join(full_output_folder, file)
             images = tensor_to_bytes(images)
             if pingpong:
                 images = np.concatenate((images, images[-2:0:-1]))

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -16,9 +16,9 @@ from .load_video_nodes import LoadVideoUpload, LoadVideoPath
 from .load_images_nodes import LoadImagesFromDirectoryUpload, LoadImagesFromDirectoryPath
 from .utils import ffmpeg_path, get_audio, calculate_file_hash
 
-folder_paths.folder_names_and_paths["video_formats"] = (
+folder_paths.folder_names_and_paths["VHS_video_formats"] = (
     [
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "video_formats"),
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "VHS_video_formats"),
     ],
     [".json"]
 )
@@ -39,9 +39,9 @@ def gen_format_widgets(video_format):
 
 def get_video_formats():
     formats = []
-    for format_name in folder_paths.get_filename_list("video_formats"):
+    for format_name in folder_paths.get_filename_list("VHS_video_formats"):
         format_name = format_name[:-5]
-        video_format_path = folder_paths.get_full_path("video_formats", format_name + ".json")
+        video_format_path = folder_paths.get_full_path("VHS_video_formats", format_name + ".json")
         with open(video_format_path, 'r') as stream:
             video_format = json.load(stream)
         widgets = [w[0] for w in gen_format_widgets(video_format)]
@@ -52,7 +52,7 @@ def get_video_formats():
     return formats
 
 def apply_format_widgets(format_name, kwargs):
-    video_format_path = folder_paths.get_full_path("video_formats", format_name + ".json")
+    video_format_path = folder_paths.get_full_path("VHS_video_formats", format_name + ".json")
     with open(video_format_path, 'r') as stream:
         video_format = json.load(stream)
     for w in gen_format_widgets(video_format):
@@ -201,7 +201,7 @@ class VideoCombine:
                 #Should never be reachable
                 raise ProcessLookupError("Could not find ffmpeg")
 
-            video_format_path = folder_paths.get_full_path("video_formats", format_ext + ".json")
+            video_format_path = folder_paths.get_full_path("VHS_video_formats", format_ext + ".json")
             with open(video_format_path, 'r') as stream:
                 video_format = json.load(stream)
             video_format = apply_format_widgets(format_ext, kwargs)

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -88,7 +88,7 @@ class VideoCombine:
                 "filename_prefix": ("STRING", {"default": "AnimateDiff"}),
                 "format": (["image/gif", "image/webp"] + ffmpeg_formats,),
                 "pingpong": ("BOOLEAN", {"default": False}),
-                "save_image": ("BOOLEAN", {"default": True}),
+                "save_output": ("BOOLEAN", {"default": True}),
             },
             "optional": {
                 "audio": ("VHS_AUDIO",),
@@ -114,7 +114,7 @@ class VideoCombine:
         filename_prefix="AnimateDiff",
         format="image/gif",
         pingpong=False,
-        save_image=True,
+        save_output=True,
         prompt=None,
         extra_pnginfo=None,
         audio=None,
@@ -126,7 +126,7 @@ class VideoCombine:
         # get output information
         output_dir = (
             folder_paths.get_output_directory()
-            if save_image
+            if save_output
             else folder_paths.get_temp_directory()
         )
         (
@@ -295,7 +295,7 @@ class VideoCombine:
             {
                 "filename": file,
                 "subfolder": subfolder,
-                "type": "output" if save_image else "temp",
+                "type": "output" if save_output else "temp",
                 "format": format,
             }
         ]

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -91,7 +91,7 @@ class VideoCombine:
                 "save_image": ("BOOLEAN", {"default": True}),
             },
             "optional": {
-                "audio": ("AUDIO",),
+                "audio": ("VHS_AUDIO",),
             },
             "hidden": {
                 "prompt": "PROMPT",
@@ -312,7 +312,8 @@ class LoadAudio:
             "optional" : {"seek_seconds": ("FLOAT", {"default": 0, "min": 0})}
         }
 
-    RETURN_TYPES = ("AUDIO",)
+    RETURN_TYPES = ("VHS_AUDIO",)
+    RETURN_NAMES = ("audio",)
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
     FUNCTION = "load_audio"
     def load_audio(self, audio_file, seek_seconds):

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -18,7 +18,7 @@ from .utils import ffmpeg_path, get_audio, calculate_file_hash
 
 folder_paths.folder_names_and_paths["VHS_video_formats"] = (
     [
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "VHS_video_formats"),
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "video_formats"),
     ],
     [".json"]
 )

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -63,8 +63,14 @@ async def view_video(request):
         vfilters.append(f"select=not(mod(n\\,{query['select_every_nth']}))")
     if query.get('force_size','Disabled') != "Disabled":
         size = query['force_size'].split('x')
-        size[0] = "-2" if size[0] == '?' else f"'min({size[0]},iw)'"
-        size[1] = "-2" if size[1] == '?' else f"'min({size[1]},ih)'"
+        if size[0] == '?' or size[1] == '?':
+            size[0] = "-2" if size[0] == '?' else f"'min({size[0]},iw)'"
+            size[1] = "-2" if size[1] == '?' else f"'min({size[1]},ih)'"
+        else:
+            #Aspect ratio is likely changed. A more complex command is required
+            #to crop the output to the new aspect ratio
+            ar = float(size[0])/float(size[1])
+            vfilters.append(f"crop=if(gt({ar}\\,a)\\,iw\\,ih*{ar}):if(gt({ar}\\,a)\\,iw/{ar}\\,ih)")
         size = ':'.join(size)
         vfilters.append(f"scale={size}")
     vfilters.append("setpts=PTS-STARTPTS")

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -50,7 +50,7 @@ async def view_video(request):
     args = ["ffmpeg", "-v", "error","-an", "-i", file]
     vfilters = []
     if int(query.get('force_rate',0)) != 0:
-        vfilters.append("fps=fps="+query['force_rate'] + ":round=up")
+        vfilters.append("fps=fps="+query['force_rate'] + ":round=up:start_time=0.001")
     if int(query.get('skip_first_frames', 0)) > 0:
         vfilters.append(f"select=gt(n\\,{int(query['skip_first_frames'])-1})")
     if int(query.get('select_every_nth', 1)) > 1:

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -2,6 +2,7 @@ import server
 import folder_paths
 import os
 import subprocess
+from .utils import is_url
 
 web = server.web
 
@@ -22,32 +23,37 @@ async def view_video(request):
     if "filename" not in query:
         return web.Response(status=404)
     filename = query["filename"]
-    filename, output_dir = folder_paths.annotated_filepath(filename)
 
-    type = request.rel_url.query.get("type", "output")
-    if type == "path":
-        #special case for path_based nodes
-        #NOTE: output_dir may be empty, but non-None
-        output_dir, filename = os.path.split(filename)
-    if output_dir is None:
-        output_dir = folder_paths.get_directory_by_type(type)
+    #Path code misformats urls on windows and must be skipped
+    if is_url(filename):
+        file = filename
+    else:
+        filename, output_dir = folder_paths.annotated_filepath(filename)
 
-    if output_dir is None:
-        return web.Response(status=400)
+        type = request.rel_url.query.get("type", "output")
+        if type == "path":
+            #special case for path_based nodes
+            #NOTE: output_dir may be empty, but non-None
+            output_dir, filename = os.path.split(filename)
+        if output_dir is None:
+            output_dir = folder_paths.get_directory_by_type(type)
 
-    if not is_safe(output_dir):
-        return web.Response(status=403)
+        if output_dir is None:
+            return web.Response(status=400)
 
-    if "subfolder" in request.rel_url.query:
-        output_dir = os.path.join(output_dir, request.rel_url.query["subfolder"])
+        if not is_safe(output_dir):
+            return web.Response(status=403)
 
-    filename = os.path.basename(filename)
-    file = os.path.join(output_dir, filename)
+        if "subfolder" in request.rel_url.query:
+            output_dir = os.path.join(output_dir, request.rel_url.query["subfolder"])
 
-    if not os.path.isfile(file):
-        return web.Response(status=404)
+        filename = os.path.basename(filename)
+        file = os.path.join(output_dir, filename)
 
-    args = ["ffmpeg", "-v", "fatal","-an", "-i", file]
+        if not os.path.isfile(file):
+            return web.Response(status=404)
+
+    args = ["ffmpeg", "-v", "error","-an", "-i", file]
     vfilters = []
     if int(query.get('force_rate',0)) != 0:
         vfilters.append("fps=fps="+query['force_rate'] + ":round=up:start_time=0.001")
@@ -69,26 +75,25 @@ async def view_video(request):
     args += ['-c:v', 'libvpx-vp9','-deadline', 'realtime', '-cpu-used', '8', '-f', 'webm', '-']
 
     try:
-        #TODO: Reconsider stderr handling here.
-        #Capturing requires giving up on streaming or risking deadlocke
-        #Muting risks eating meaningful errors
         with subprocess.Popen(args, stdout=subprocess.PIPE) as proc:
-            resp = web.StreamResponse()
-            resp.content_type = 'video/webm'
-            resp.headers["Content-Disposition"] = f"filename=\"{filename}\""
-            await resp.prepare(request)
-            while True:
-                bytes_read = proc.stdout.read()
-                if bytes_read is None:
-                    #TODO: check for timeout here
-                    time.sleep(.1)
-                    continue
-                if len(bytes_read) == 0:
-                    break
-                await resp.write(bytes_read)
+            try:
+                resp = web.StreamResponse()
+                resp.content_type = 'video/webm'
+                resp.headers["Content-Disposition"] = f"filename=\"{filename}\""
+                await resp.prepare(request)
+                while True:
+                    bytes_read = proc.stdout.read()
+                    if bytes_read is None:
+                        #TODO: check for timeout here
+                        time.sleep(.1)
+                        continue
+                    if len(bytes_read) == 0:
+                        break
+                    await resp.write(bytes_read)
+            except ConnectionResetError as e:
+                #Kill ffmpeg before stdout closes
+                proc.kill()
     except BrokenPipeError as e:
-        pass
-    except ConnectionResetError as e:
         pass
     return resp
 

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -1,0 +1,96 @@
+import server
+import folder_paths
+import os
+import subprocess
+
+web = server.web
+
+@server.PromptServer.instance.routes.get("/viewvideo")
+async def view_video(request):
+    query = request.rel_url.query
+    if "filename" not in query:
+        return web.Response(status=404)
+    filename = query["filename"]
+    filename, output_dir = folder_paths.annotated_filepath(filename)
+
+    filename,output_dir = folder_paths.annotated_filepath(filename)
+
+    # validation for security: prevent accessing arbitrary path
+    if filename[0] == '/' or '..' in filename:
+        return web.Response(status=400)
+
+    if output_dir is None:
+        type = request.rel_url.query.get("type", "output")
+        output_dir = folder_paths.get_directory_by_type(type)
+
+    if output_dir is None:
+        return web.Response(status=400)
+
+    if "subfolder" in request.rel_url.query:
+        full_output_dir = os.path.join(output_dir, request.rel_url.query["subfolder"])
+        if os.path.commonpath((os.path.abspath(full_output_dir), output_dir)) != output_dir:
+            return web.Response(status=403)
+        output_dir = full_output_dir
+
+    filename = os.path.basename(filename)
+    file = os.path.join(output_dir, filename)
+
+    if not os.path.isfile(file):
+        return web.Response(status=404)
+
+    args = ["ffmpeg", "-v", "error", "-i", file]
+    vfilters = []
+    if int(query.get('force_rate',0)) != 0:
+        vfilters.append("fps=fps="+query['force_rate'] + ":round=up")
+    if int(query.get('skip_first_frames', 0)) > 0:
+        vfilters.append(f"select=gt(n\\,{int(query['skip_first_frames'])-1})")
+    if query.get('force_size','Disabled') != "Disabled":
+        size = query['force_size'].replace('?','-2').replace('x',':')
+        vfilters.append(f"scale={size}")
+    if len(vfilters) > 0:
+        args += ["-vf", ",".join(vfilters)]
+    if int(query.get('frame_load_cap', 0)) > 0:
+        args += ["-frames:v", query['frame_load_cap']]
+    args += ['-f', 'webm', '-']
+
+    with subprocess.Popen(args, stdout=subprocess.PIPE) as proc:
+        resp = web.StreamResponse()
+        resp.content_type = 'video/webm'
+        resp.headers["Content-Disposition"] = f"filename=\"{filename}\""
+        await resp.prepare(request)
+        while True:
+            bytes_read = proc.stdout.read()
+            if bytes_read is None:
+                #TODO: check for timeout here
+                time.sleep(.1)
+                continue
+            if len(bytes_read) == 0:
+                break
+            await resp.write(bytes_read)
+        return resp
+
+@server.PromptServer.instance.routes.get("/getpath")
+async def get_path(request):
+    query = request.rel_url.query
+    if "path" not in query:
+        return web.Response(status=404)
+    path = os.path.abspath(query["path"])
+
+    #For now, only continue if subpath of comfui
+    basedir = os.path.abspath('.')
+    common_path = os.path.commonpath([basedir, path])
+    if common_path != basedir or not os.path.exists(path):
+        return web.Response(status=404)
+
+    #Use get so None is default instead of keyerror
+    valid_extensions = query.get("extensions")
+    valid_items = []
+    for item in os.scandir(path):
+        #TODO: change type to designate if dir or file
+        if item.is_dir():
+            valid_items.append(item.name + "/")
+            continue
+        if valid_extensions is None or item.name.split(".")[-1] in valid_extensions:
+            valid_items.append(item.name)
+
+    return web.json_response(valid_items)

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -111,10 +111,14 @@ async def get_path(request):
     valid_extensions = query.get("extensions")
     valid_items = []
     for item in os.scandir(path):
-        if item.is_dir():
-            valid_items.append(item.name + "/")
-            continue
-        if valid_extensions is None or item.name.split(".")[-1] in valid_extensions:
-            valid_items.append(item.name)
+        try:
+            if item.is_dir():
+                valid_items.append(item.name + "/")
+                continue
+            if valid_extensions is None or item.name.split(".")[-1] in valid_extensions:
+                valid_items.append(item.name)
+        except OSError:
+            #Broken symlinks can throw a very unhelpful "Invalid argument"
+            pass
 
     return web.json_response(valid_items)

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -68,7 +68,7 @@ async def view_video(request):
                 if len(bytes_read) == 0:
                     break
                 await resp.write(bytes_read)
-    except:
+    except BrokenPipeError as e:
         pass
     return resp
 

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -7,7 +7,7 @@ from .utils import is_url
 web = server.web
 
 def is_safe(path):
-    if "VHS_UNSAFE_PATHS" in os.environ:
+    if "VHS_STRICT_PATHS" not in os.environ:
         return True
     basedir = os.path.abspath('.')
     try:
@@ -78,6 +78,8 @@ async def view_video(request):
         args += ["-vf", ",".join(vfilters)]
     if int(query.get('frame_load_cap', 0)) > 0:
         args += ["-frames:v", query['frame_load_cap']]
+    #TODO:reconsider adding high frame cap/setting default frame cap on node
+
     args += ['-c:v', 'libvpx-vp9','-deadline', 'realtime', '-cpu-used', '8', '-f', 'webm', '-']
 
     try:

--- a/videohelpersuite/utils.py
+++ b/videohelpersuite/utils.py
@@ -7,13 +7,14 @@ import subprocess
 from .logger import logger
 
 ffmpeg_path = shutil.which("ffmpeg")
-if ffmpeg_path is None:
-    logger.info("ffmpeg could not be found. Using ffmpeg from imageio-ffmpeg.")
-    from imageio_ffmpeg import get_ffmpeg_exe
+if "VHS_USE_IMAGEIO_FFMPEG" in os.environ or ffmpeg_path is None:
     try:
+        from imageio_ffmpeg import get_ffmpeg_exe
         ffmpeg_path = get_ffmpeg_exe()
     except:
-        logger.warning("ffmpeg could not be found. Outputs that require it have been disabled")
+        logger.warn("Failed to import imageio_ffmpeg")
+if ffmpeg_path is None:
+    logger.warning("ffmpeg could not be found. Outputs that require it have been disabled")
 
 def get_sorted_dir_files_from_directory(directory: str, skip_first_images: int=0, select_every_nth: int=1, extensions: Iterable=None):
     directory = directory.strip()

--- a/videohelpersuite/utils.py
+++ b/videohelpersuite/utils.py
@@ -1,7 +1,16 @@
 import hashlib
 import os
 from typing import Iterable
+import shutil
 
+ffmpeg_path = shutil.which("ffmpeg")
+if ffmpeg_path is None:
+    logger.info("ffmpeg could not be found. Using ffmpeg from imageio-ffmpeg.")
+    from imageio_ffmpeg import get_ffmpeg_exe
+    try:
+        ffmpeg_path = get_ffmpeg_exe()
+    except:
+        logger.warning("ffmpeg could not be found. Outputs that require it have been disabled")
 
 def get_sorted_dir_files_from_directory(directory: str, skip_first_images: int=0, select_every_nth: int=1, extensions: Iterable=None):
     directory = directory.strip()

--- a/videohelpersuite/utils.py
+++ b/videohelpersuite/utils.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 from typing import Iterable
 import shutil
+import subprocess
 
 ffmpeg_path = shutil.which("ffmpeg")
 if ffmpeg_path is None:
@@ -45,3 +46,23 @@ def calculate_file_hash(filename: str, hash_every_n: int = 1):
                 h.update(mv[:n])
             i += 1
     return h.hexdigest()
+
+def get_audio(file, start_time=0, duration=0):
+    args = [ffmpeg_path, "-v", "error", "-i", file]
+    if start_time > 0:
+        args += ["-ss", str(start_time)]
+    if duration > 0:
+        args += ["-t", str(duration)]
+    return subprocess.run(args + ["-f", "wav", "-"],
+                          stdout=subprocess.PIPE, check=True).stdout
+def lazy_eval(func):
+    class Cache:
+        def __init__(self, func):
+            self.res = None
+            self.func = func
+        def get(self):
+            if self.res is None:
+                self.res = self.func()
+            return self.res
+    cache = Cache(func)
+    return lambda : cache.get()

--- a/videohelpersuite/utils.py
+++ b/videohelpersuite/utils.py
@@ -4,6 +4,8 @@ from typing import Iterable
 import shutil
 import subprocess
 
+from .logger import logger
+
 ffmpeg_path = shutil.which("ffmpeg")
 if ffmpeg_path is None:
     logger.info("ffmpeg could not be found. Using ffmpeg from imageio-ffmpeg.")

--- a/videohelpersuite/utils.py
+++ b/videohelpersuite/utils.py
@@ -68,3 +68,6 @@ def lazy_eval(func):
             return self.res
     cache = Cache(func)
     return lambda : cache.get()
+
+def is_url(url):
+    return url.split("://")[0] in ["http", "https"]

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -47,6 +47,7 @@ const convDict = {
     VHS_LoadVideo : ["video", "force_rate", "force_size", "frame_load_cap", "skip_first_frames", "select_every_nth"],
     VHS_LoadVideoPath : ["video", "force_rate", "force_size", "frame_load_cap", "skip_first_frames", "select_every_nth"]
 };
+const renameDict  = {VHS_VideoCombine : {save_output : "save_image"}}
 function useKVState(nodeType) {
     chainCallback(nodeType.prototype, "onNodeCreated", function () {
         chainCallback(this, "onConfigure", function(info) {
@@ -85,6 +86,13 @@ function useKVState(nodeType) {
                     if (w.name in widgetDict) {
                         w.value = widgetDict[w.name];
                     } else {
+                        //Check for a legacy name that needs migrating
+                        if (this.type in renameDict && w.name in renameDict[this.type]) {
+                            if (renameDict[this.type][w.name] in widgetDict) {
+                                w.value = widgetDict[renameDict[this.type][w.name]]
+                                continue
+                            }
+                        }
                         //attempt to restore default value
                         let inputs = LiteGraph.getNodeType(this.type).nodeData.input;
                         let initialValue = null;

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -502,7 +502,7 @@ function addVideoPreview(nodeType) {
                     //overscale to allow scrolling. Endpoint won't return higher than native
                     target_width = this.parentEl.style.width.slice(0,-2)*2;
                 }
-                if (!params.force_size || params.force_size.includes("?")) {
+                if (!params.force_size || params.force_size.includes("?") || params.force_size == "Disabled") {
                     params.force_size = target_width+"x?"
                 } else {
                     let size = params.force_size.split("x")

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1,5 +1,7 @@
 import { app } from '../../../scripts/app.js'
 import { api } from '../../../scripts/api.js'
+import { applyTextReplacements } from "../../../scripts/utils.js";
+
 
 function chainCallback(object, property, callback) {
     if (object == undefined) {
@@ -174,40 +176,11 @@ async function uploadFile(file) {
     }
 }
 
-function formatDate(text, date) {
-    const parts = {
-        d: (d) => d.getDate(),
-        M: (d) => d.getMonth() + 1,
-        h: (d) => d.getHours(),
-        m: (d) => d.getMinutes(),
-        s: (d) => d.getSeconds(),
-    };
-    const format =
-        Object.keys(parts)
-        .map((k) => k + k + "?")
-        .join("|") + "|yyy?y?";
-    return text.replace(new RegExp(format, "g"), function (text) {
-        if (text === "yy") return (date.getFullYear() + "").substring(2);
-        if (text === "yyyy") return date.getFullYear();
-        if (text[0] in parts) {
-            const p = parts[text[0]](date);
-            return (p + "").padStart(text.length, "0");
-        }
-        return text;
-    });
-}
-
 function addDateFormatting(nodeType, field, timestamp_widget = false) {
     chainCallback(nodeType.prototype, "onNodeCreated", function() {
-        const widget = this.widgets.find((w) => w.name === "filename_prefix");
+        const widget = this.widgets.find((w) => w.name === field);
         widget.serializeValue = () => {
-            return widget.value.replace(/%([^%]+)%/g, function (match, text) {
-                const split = text.split(".");
-                if (split[0].startsWith("date:")) {
-                    return formatDate(split[0].substring(5), new Date());
-                }
-                return match;
-            });
+            return applyTextReplacements(app, widget.value);
         };
     });
 }

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -451,7 +451,7 @@ function addVideoPreview(nodeType) {
                 return
             }
             previewWidget.parentEl.hidden = previewWidget.value.hidden;
-            if (params?.format?.split('/')[0] == 'video') {
+            if (params?.format?.split('/')[0] == 'video' || app.ui.settings.getSettingValue("VHS.AdvancedPreviews", false)) {
                 previewWidget.videoEl.autoplay = !previewWidget.value.paused && !previewWidget.value.hidden;
                 //TODO: Add in ui config option to disable rendered previews
                 if (previewWidget.parentEl.style?.width) {

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -292,6 +292,17 @@ function addCustomSize(nodeType, nodeData, widgetName) {
                 return this._value;
             }
         });
+        //prevent clobbering of new options on refresh
+        sizeOptionWidget.options._values = sizeOptionWidget.options.values;
+        Object.defineProperty(sizeOptionWidget.options, "values", {
+            set : function(values) {
+                this._values = values;
+                this._values.push("Custom Width", "Custom Height", "Custom");
+            },
+            get : function() {
+                return this._values;
+            }
+        });
         //Ensure proper visibility/size state for initial value
         sizeOptionWidget.value = sizeOptionWidget._value;
 
@@ -456,6 +467,9 @@ function addVideoPreview(nodeType) {
         var timeout = null;
         this.updateParameters = (params, force_update) => {
             if (!previewWidget.value.params) {
+                if(typeof(previewWidget.value != 'object')) {
+                    previewWidget.value =  {hidden: false, paused: false}
+                }
                 previewWidget.value.params = {}
             }
             Object.assign(previewWidget.value.params, params)

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -472,7 +472,8 @@ function addVideoPreview(nodeType) {
                 params.format?.split('/')[1] == 'gif') {
                 this.videoEl.autoplay = !this.value.paused && !this.value.hidden;
                 if (this.parentEl.style?.width) {
-                    params.force_size = this.parentEl.style.width.slice(0,-2) + "x?";
+                    //overscale to allow scrolling. Endpoint won't return higher than native
+                    params.force_size = (this.parentEl.style.width.slice(0,-2)*2) + "x?";
                 } else {
                     params.force_size = "256x?"
                 }
@@ -636,6 +637,9 @@ function addFormatWidgets(nodeType) {
                     formatWidget._value = fullDef[0];
                     for (let wDef of fullDef[1]) {
                         //create widgets. Heavy borrowed from web/scripts/app.js
+                        //default implementation doesn't work since it automatically adds
+                        //the widget in the wrong spot.
+                        //TODO: consider letting this happen and just removing from list?
                         let w = {};
                         w.name = wDef[0];
                         let inputData = wDef.slice(1);
@@ -649,11 +653,17 @@ function addFormatWidgets(nodeType) {
                         if(inputData[1]?.default) {
                             w.value = inputData[1].default;
                         }
+                        if (w.type == "INT") {
+                            Object.assign(w.options, {"precision": 0, "step": 10})
+                            w.callback = function (v) {
+                                const s = this.options.step / 10;
+                                this.value = Math.round(v / s) * s;
+                            }
+                        }
                         const typeTable = {BOOLEAN: "toggle", STRING: "text", INT: "number", FLOAT: "number"};
                         if (w.type in typeTable) {
                             w.type = typeTable[w.type];
                         }
-                        //TODO: implement precision/rounding/step
                         newWidgets.push(w);
                     }
                 }

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -447,6 +447,9 @@ function addVideoPreview(nodeType) {
 
         var timeout = null;
         this.updateParameters = (params, force_update) => {
+            if (!previewWidget.value.params) {
+                previewWidget.value.params = {}
+            }
             Object.assign(previewWidget.value.params, params)
             if (!force_update &&
                 !app.ui.settings.getSettingValue("VHS.AdvancedPreviews", false)) {
@@ -534,7 +537,7 @@ function addPreviewOptions(nodeType) {
                     callback: () => {
                         const a = document.createElement("a");
                         a.href = url;
-                        a.setAttribute("download", new URLSearchParams(url.search).get("filename"));
+                        a.setAttribute("download", new URLSearchParams(previewWidget.value.params).get("filename"));
                         document.body.append(a);
                         a.click();
                         requestAnimationFrame(() => a.remove());
@@ -1006,7 +1009,7 @@ app.registerExtension({
                         let partial = path.substr(path.length - (isAbs ? 28:29))
                         let cutoff = partial.indexOf('/');
                         if (cutoff < 0) {
-                            console.warn("Failed to pretty format: " + path);
+                            //Can occur, but there isn't a nicer way to format
                             return path.substr(path.length-30);
                         }
                         return (isAbs ? '/…':'…') + partial.substr(cutoff);

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -291,7 +291,7 @@ function addCustomSize(nodeType, nodeData, widgetName) {
             if (this.value == "Custom Width") {
                 return widthWidget.value + "x?";
             } else if (this.value == "Custom Height") {
-                return "?x" + heightWidget;
+                return "?x" + heightWidget.value;
             } else if (this.value == "Custom") {
                 return widthWidget.value + "x" + heightWidget.value;
             } else {
@@ -879,6 +879,7 @@ app.registerExtension({
                     if (["gif", "webp", "avif"].includes(extension)) {
                         format = "image"
                     }
+                    format += "/" + extension;
                     let params = {filename : parts[1], type : parts[0], format: format};
                     this.updateParameters(params, true);
                 });
@@ -894,6 +895,7 @@ app.registerExtension({
                     if (["gif", "webp", "avif"].includes(extension)) {
                         format = "image"
                     }
+                    format += "/" + extension;
                     let params = {filename : value, type: "path", format: format};
                     this.updateParameters(params, true);
                 });

--- a/web/js/videoinfo.js
+++ b/web/js/videoinfo.js
@@ -81,6 +81,8 @@ function isVideoFile(file) {
     return false;
 }
 
+let originalHandleFile = app.handleFile;
+app.handleFile = handleFile;
 async function handleFile(file) {
     if (file?.type?.startsWith("video/") || isVideoFile(file)) {
         const videoInfo = await getVideoMetadata(file);
@@ -92,13 +94,9 @@ async function handleFile(file) {
             //Potentially check for/parse A1111 metadata here.
         }
     } else {
-        await app.originalHandleFile(file);
+        return await originalHandleFile.apply(this, arguments);
     }
 }
 
-//Storing the original function in app is probably a major no-no
-//But it's the only way I've found to keep the 'this' reference
-app.originalHandleFile = app.handleFile;
-app.handleFile = handleFile;
 //hijack comfy-file-input to allow webm/mp4
 document.getElementById("comfy-file-input").accept += ",video/webm,video/mp4";


### PR DESCRIPTION
There's a lot of changes here, but I've finally run out of things to test. I'm thinking it's best to delay merging until after the weekend rush, but it should be stable enough for others to test. This would also give time to update and include the README branch.

This pull request combines 5 different feature branches I've been working on and numerous fixes for several longstanding issues that had been relegated.
![bluebird](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/assets/4284322/4e7792d3-9b58-4928-9796-95beea7479c5)
Much of the additional features have been designed to be opt in, but this can be changed later.
### Advanced Previews
- Only used if a new VHS Advanced Previews setting is enabled in the webui settings menu.
  - Despite my best efforts to stream the video as it's processing, in browser playback blocks until the whole preview is sent.
- Causes video previews to reflect the settings on load nodes and be downscaled based on node size.
- Adds preview support for Load Video (Path)
### Format Widgets
Allows for video_formats to expose arbitrary options as widgets. Existing formats will continue to work unchanged.
### Path Suggestions
- Limited to subdirectories of comfyui unless `VHS_UNSAFE_PATHS` is set as an environment variable
- Has rudimentary keyboard shortcut support including completion with tab and deletion with ctrl+w (browser dependent)
- Properly setup to be configured entirely in python code.
### High Bit Depth
After further testing, it actually provides measurablly increased quality compared to save image, but only on some images and only with post-processing.  
As an example, when the dark hair in this image is substantially brightened, there is a noticable difference in detail and greatly reduced banding.
![bit-depth2](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/assets/4284322/60f508ed-1834-4708-a5f3-3f904a8e64ab)
As I only see a difference under controlled situations and it comes at a cost to performance/compatibility, it's disabled unless a format has `input_color_depth` set to `16bit`.  
Currently, this is only applied as an option for av1-webm where it is disabled by default
### Audio
- Load Video nodes now provide an audio output and a new Load Audio node has been added to retain support for standalone audio files.  
  - As extracting audio requires a seperate pass, audio is lazily loaded when it is used and cached afterwards.  
- Settings for audio encoding are available as a new `audio_pass` field in video_formats