### PR TITLE
Add h264_nvenc, hevc_nvenc (NVIDIA) hw encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+# VIM swap files
+*.swp

--- a/video_formats/h265-mp4.json
+++ b/video_formats/h265-mp4.json
@@ -2,6 +2,7 @@
     "main_pass":
     [
         "-n", "-c:v", "libx265",
+        "-vtag", "hvc1",
         "-pix_fmt", ["pix_fmt", ["yuv420p10le", "yuv420p"]],
         "-crf", ["crf","INT", {"default": 22, "min": 0, "max": 100, "step": 1}],
         "-preset", "medium",

--- a/video_formats/nvenc_h264-mp4.json
+++ b/video_formats/nvenc_h264-mp4.json
@@ -1,0 +1,12 @@
+{
+    "main_pass":
+    [
+        "-n", "-c:v", "h264_nvenc",
+        "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le"]]
+    ],
+    "audio_pass": ["-c:a", "aac"],
+    "bitrate": ["bitrate","INT", {"default": 10, "min": 1, "max": 999, "step": 1 }],
+    "megabit": ["megabit","BOOLEAN", {"default": true}],
+    "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],
+    "extension": "mp4"
+}

--- a/video_formats/nvenc_hevc-mp4.json
+++ b/video_formats/nvenc_hevc-mp4.json
@@ -1,0 +1,13 @@
+{
+    "main_pass":
+    [
+        "-n", "-c:v", "hevc_nvenc",
+        "-vtag", "hvc1",
+        "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le"]]
+    ],
+    "audio_pass": ["-c:a", "aac"],
+    "bitrate": ["bitrate","INT", {"default": 10, "min": 1, "max": 999, "step": 1 }],
+    "megabit": ["megabit","BOOLEAN", {"default": true}],
+    "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],
+    "extension": "mp4"
+}

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -217,9 +217,13 @@ class VideoCombine:
             file_path = os.path.join(full_output_folder, file)
             dimensions = f"{len(images[0][0])}x{len(images[0])}"
             loop_args = ["-vf", "loop=loop=" + str(loop_count)+":size=" + str(len(images))]
+            bitrate_arg = []
+            bitrate = video_format.get('bitrate')
+            if bitrate is not None:
+                bitrate_arg = ["-b:v", str(bitrate) + "M" if video_format.get('megabit') == 'True' else str(bitrate) + "K"]
             args = [ffmpeg_path, "-v", "error", "-f", "rawvideo", "-pix_fmt", i_pix_fmt,
                     "-s", dimensions, "-r", str(frame_rate), "-i", "-"] \
-                    + loop_args + video_format['main_pass']
+                    + loop_args + video_format['main_pass'] + bitrate_arg
 
             env=os.environ.copy()
             if  "environment" in video_format:


### PR DESCRIPTION
In Video Combine, libx264 may crash with 1000+ input images.

To avoid the crash, add hardware encoding supported by NVIDIA GPUs.

Add bitrate option which precludes crf.
Add megabit option, which so the user may specify bitrate in Mb or Kb.
Add hvc1 video tag, for better support on with Apple quicktime - to hevc_nvenc and libx265 video formats.
    This allows previews to show up in Safari too.

Add *.swp to .gitignore.