### PR TITLE
Fix load_image validation, old version validation

### DIFF
--- a/videohelpersuite/load_images_nodes.py
+++ b/videohelpersuite/load_images_nodes.py
@@ -114,7 +114,7 @@ class LoadImagesFromDirectoryUpload:
         return is_changed_load_images(directory, **kwargs)
 
     @classmethod
-    def VALIDATE_INPUTS(s, directory: str):
+    def VALIDATE_INPUTS(s, directory: str, **kwargs):
         directory = folder_paths.get_annotated_filepath(directory.strip())
         return validate_load_images(directory)
 
@@ -139,7 +139,7 @@ class LoadImagesFromDirectoryPath:
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
 
     def load_images(self, directory: str, **kwargs):
-        if directory is None or validate_load_images(directory, **kwargs) != True:
+        if directory is None or validate_load_images(directory) != True:
             raise Exception("directory is not valid: " + directory)
 
         return load_images(directory, **kwargs)
@@ -151,7 +151,7 @@ class LoadImagesFromDirectoryPath:
         return is_changed_load_images(directory, **kwargs)
 
     @classmethod
-    def VALIDATE_INPUTS(s, directory: str):
+    def VALIDATE_INPUTS(s, directory: str, **kwargs):
         if directory is None:
             return True
         return validate_load_images(directory)

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -142,7 +142,7 @@ class LoadVideoUpload:
         return calculate_file_hash(image_path)
 
     @classmethod
-    def VALIDATE_INPUTS(s, video, force_size):
+    def VALIDATE_INPUTS(s, video, force_size, **kwargs):
         if not folder_paths.exists_annotated_filepath(video):
             return "Invalid video file: {}".format(video)
         return True
@@ -178,5 +178,5 @@ class LoadVideoPath:
         return hash_path(video)
 
     @classmethod
-    def VALIDATE_INPUTS(s, video, force_size):
+    def VALIDATE_INPUTS(s, video, force_size, **kwargs):
         return validate_path(video, allow_none=True)

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -308,7 +308,7 @@ class VideoCombine:
         ]
         return {"ui": {"gifs": previews}, "result": ((save_output, output_files),)}
     @classmethod
-    def VALIDATE_INPUTS(self, format):
+    def VALIDATE_INPUTS(self, format, **kwargs):
         return True
 
 class LoadAudio:
@@ -339,7 +339,7 @@ class LoadAudio:
         return hash_path(audio_file)
 
     @classmethod
-    def VALIDATE_INPUTS(s, audio_file):
+    def VALIDATE_INPUTS(s, audio_file, **kwargs):
         return validate_path(audio_file, allow_none=True)
 
 NODE_CLASS_MAPPINGS = {


### PR DESCRIPTION
Removing the obsolete kwargs arg from VALIDATE_INPUT methods was done too soon. It has been reintroduced so that older versions of ComfyUI remain compatible.

Fix failure to update the validation call at execution time of Load Images.

Resolves #113