### PR TITLE
Added VAE Decode Batched and VAE Encode Batched

### DIFF
--- a/videohelpersuite/batched_nodes.py
+++ b/videohelpersuite/batched_nodes.py
@@ -1,0 +1,48 @@
+import torch
+from nodes import VAEEncode
+
+
+class VAEDecodeBatched:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "samples": ("LATENT", ),
+                "vae": ("VAE", ),
+                "per_batch": ("INT", {"default": 16, "min": 1})
+                }
+            }
+    
+    CATEGORY = "Video Helper Suite 🎥🅥🅗🅢/batched nodes"
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "decode"
+
+    def decode(self, vae, samples, per_batch):
+        decoded = []
+        for start_idx in range(0, samples["samples"].shape[0], per_batch):
+            decoded.append(vae.decode(samples["samples"][start_idx:start_idx+per_batch]))
+        return (torch.cat(decoded, dim=0), )
+
+
+class VAEEncodeBatched:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "pixels": ("IMAGE", ), "vae": ("VAE", ),
+                "per_batch": ("INT", {"default": 16, "min": 1})
+                }
+            }
+    
+    CATEGORY = "Video Helper Suite 🎥🅥🅗🅢/batched nodes"
+
+    RETURN_TYPES = ("LATENT",)
+    FUNCTION = "encode"
+
+    def encode(self, vae, pixels, per_batch):
+        t = []
+        for start_idx in range(0, pixels.shape[0], per_batch):
+            sub_pixels = VAEEncode.vae_encode_crop_pixels(pixels[start_idx:start_idx+per_batch])
+            t.append(vae.encode(sub_pixels[:,:,:,:3]))
+        return ({"samples": torch.cat(t, dim=0)}, )

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -14,6 +14,7 @@ from .logger import logger
 from .image_latent_nodes import DuplicateImages, DuplicateLatents, GetImageCount, GetLatentCount, MergeImages, MergeLatents, SelectEveryNthImage, SelectEveryNthLatent, SplitLatents, SplitImages
 from .load_video_nodes import LoadVideoUpload, LoadVideoPath
 from .load_images_nodes import LoadImagesFromDirectoryUpload, LoadImagesFromDirectoryPath
+from .batched_nodes import VAEEncodeBatched, VAEDecodeBatched
 from .utils import ffmpeg_path, get_audio, hash_path, validate_path
 
 folder_paths.folder_names_and_paths["VHS_video_formats"] = (
@@ -364,6 +365,9 @@ NODE_CLASS_MAPPINGS = {
     "VHS_GetImageCount": GetImageCount,
     "VHS_DuplicateLatents": DuplicateLatents,
     "VHS_DuplicateImages": DuplicateImages,
+    # Batched Nodes
+    "VHS_VAEEncodeBatched": VAEEncodeBatched,
+    "VHS_VAEDecodeBatched": VAEDecodeBatched,
 }
 NODE_DISPLAY_NAME_MAPPINGS = {
     "VHS_VideoCombine": "Video Combine 🎥🅥🅗🅢",
@@ -383,4 +387,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "VHS_GetImageCount": "Get Image Count 🎥🅥🅗🅢",
     "VHS_DuplicateLatents": "Duplicate Latent Batch 🎥🅥🅗🅢",
     "VHS_DuplicateImages": "Duplicate Image Batch 🎥🅥🅗🅢",
+    # Batched Nodes
+    "VHS_VAEEncodeBatched": "VAE Encode Batched 🎥🅥🅗🅢",
+    "VHS_VAEDecodeBatched": "VAE Decode Batched 🎥🅥🅗🅢",
 }


### PR DESCRIPTION
Useful when encoding or decoding large groups of images/latents to avoid OOMs and can offer some speedup compared to usual VAE Encode and VAE Decode nodes.