### PR TITLE
Implement Batch Manager node

### DIFF
--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -136,6 +136,14 @@ def load_video_cv(video: str, force_rate: int, force_size: str,
             s = images.movedim(-1,1)
             s = common_upscale(s, new_size[0], new_size[1], "lanczos", "center")
             images = s.movedim(1,-1)
+    video_cap = cv2.VideoCapture(video)
+    if not video_cap.isOpened():
+        raise ValueError(f"{video} could not be loaded with cv.")
+    base_frame_time = 1/video_cap.get(cv2.CAP_PROP_FPS)
+    if force_rate == 0:
+        target_frame_time = base_frame_time
+    else:
+        target_frame_time = 1/force_rate
 
     #Setup lambda for lazy audio capture
     audio = lambda : get_audio(video, skip_first_frames * target_frame_time,

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -104,6 +104,7 @@ def cv_frame_generator(video, force_rate, frame_load_cap, skip_first_frames,
                 break
         if batch_manager is not None:
             batch_manager.inputs.pop(unique_id)
+            batch_manager.has_closed_inputs = True
         if prev_frame is not None:
             yield prev_frame
     finally:

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -258,6 +258,8 @@ class VideoCombine:
 
         format_type, format_ext = format.split("/")
         if format_type == "image":
+            if batch_manager is not None:
+                raise Exception("Pillow('image/') formats are not compatible with batched output")
             file = f"{filename}_{counter:05}.{format_ext}"
             file_path = os.path.join(full_output_folder, file)
             images = tensor_to_bytes(images)
@@ -313,6 +315,8 @@ class VideoCombine:
                 else:
                     i_pix_fmt = 'rgb24'
             if pingpong:
+                if batch_manager is not None:
+                    logger.error("pingpong is incompatible with batched output")
                 images = np.concatenate((images, images[-2:0:-1]))
             file = f"{filename}_{counter:05}.{video_format['extension']}"
             file_path = os.path.join(full_output_folder, file)

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -372,6 +372,7 @@ class VideoCombine:
                             + ["-af", "apad", "-shortest", output_file_with_audio_path]
 
                 try:
+                    env=os.environ.copy()
                     res = subprocess.run(mux_args, input=audio(), env=env,
                                          capture_output=True, check=True)
                 except subprocess.CalledProcessError as e:

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -995,6 +995,12 @@ app.registerExtension({
             //Disabled for safety as VHS_SaveImageSequence is not currently merged
             //addDateFormating(nodeType, "directory_name", timestamp_widget=true);
             //addTimestampWidget(nodeType, nodeData, "directory_name")
+        } else if (nodeData?.name == "VHS_BatchManager") {
+            chainCallback(nodeType.prototype, "onNodeCreated", function() {
+                this.widgets.push({name: "count", type: "dummy", value: 0,
+                    computeSize: () => {return [0,-4]},
+                    afterQueued: function() {this.value++;}});
+            });
         }
     },
     async getCustomWidgets() {

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -963,6 +963,12 @@ app.registerExtension({
         } else if (nodeData?.name == "VHS_VideoCombine") {
             addDateFormatting(nodeType, "filename_prefix");
             chainCallback(nodeType.prototype, "onExecuted", function(message) {
+                if (message?.unfinished_batch) {
+                    let bm = app.graph._nodes.find((n) => n.type == "VHS_BatchManager");
+                    let cw = bm.widgets.find((w) => w.name == "count");
+                    cw.value++;
+                    app.queuePrompt(0);
+                }
                 if (message?.gifs) {
                     this.updateParameters(message.gifs[0], true);
                 }
@@ -995,6 +1001,11 @@ app.registerExtension({
             //Disabled for safety as VHS_SaveImageSequence is not currently merged
             //addDateFormating(nodeType, "directory_name", timestamp_widget=true);
             //addTimestampWidget(nodeType, nodeData, "directory_name")
+        } else if (nodeData?.name == "VHS_BatchManager") {
+            chainCallback(nodeType.prototype, "onNodeCreated", function() {
+                this.widgets.push({name: "count", type: "dummy", value: 0,
+                                   computeSize: () => {return [0,-4]}})
+            });
         }
     },
     async getCustomWidgets() {


### PR DESCRIPTION
In order to provide a proper solution for processing longer video inputs, a Batch Manager node is added which will process at most  `frames_per_batch` frames in a single execution. If more input exists after an execution, the opencv video_cap and the output ffmpeg subprocess are both held open and a new execution is chained.

As a result of this implementation, video input and video output are both wrapped as generator objects even when the batch manager is not used.
- The memory required by Load Video has been cut in half as a copy from a python list into a torch tensor is no longer required.
- Since the size of video output data isn't known at execution, Video Combine has been moved from subprocess.run back to subprocess.Popen. This reintroduces the theoretical, but never observed potential for deadlock.