### PR TITLE
Add LoadAudioUpload -node

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -528,7 +528,7 @@ class LoadAudioUpload:
         return calculate_file_hash(image_path)
 
     @classmethod
-    def VALIDATE_INPUTS(s, audio, force_size, **kwargs):
+    def VALIDATE_INPUTS(s, audio, **kwargs):
         if not folder_paths.exists_annotated_filepath(audio):
             return "Invalid audio file: {}".format(audio)
         return True

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -47,7 +47,6 @@ const convDict = {
     VHS_VideoCombine : ["frame_rate", "loop_count", "filename_prefix", "format", "pingpong", "save_image"],
     VHS_LoadVideo : ["video", "force_rate", "force_size", "frame_load_cap", "skip_first_frames", "select_every_nth"],
     VHS_LoadVideoPath : ["video", "force_rate", "force_size", "frame_load_cap", "skip_first_frames", "select_every_nth"],
-    VHS_LoadAudioUpload : ["audio", "duration", "start_time"],
 };
 const renameDict  = {VHS_VideoCombine : {save_output : "save_image"}}
 function useKVState(nodeType) {
@@ -967,9 +966,6 @@ app.registerExtension({
             addLoadVideoCommon(nodeType, nodeData);
         } else if (nodeData?.name == "VHS_LoadAudioUpload") {
             addUploadWidget(nodeType, nodeData, "audio", "audio");
-            chainCallback(nodeType.prototype, "onNodeCreated", function() {
-                const pathWidget = this.widgets.find((w) => w.name === "audio");
-            });
   
         } else if (nodeData?.name =="VHS_LoadVideoPath") {
             chainCallback(nodeType.prototype, "onNodeCreated", function() {


### PR DESCRIPTION
Adds a node to allow audio file upload in same way as video upload. I find this necessary when working remotely with audio stuff, and in my opinion it easily integrates here.

Tested to be working with .mp3, .wav and .ogg from Firefox on Linux.

Still not 100% sure of all the javascript stuff especially, I don't have much js experience at all, so @AustinMroz if you could check if there's something missing or if I made a mistake.