### PR TITLE
Merge develop: Load/Combine latents, image sequence previews, skip_first on SelectEvery nodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-videohelpersuite"
 description = "Nodes related to video workflows"
-version = "1.1.2"
+version = "1.2.0"
 license = "LICENSE"
 dependencies = ["opencv-python", "imageio-ffmpeg"]
 

--- a/video_formats/8bit-png.json
+++ b/video_formats/8bit-png.json
@@ -1,0 +1,7 @@
+{
+    "main_pass":
+    [
+        "-n"
+    ],
+    "extension": "%03d.png"
+}

--- a/videohelpersuite/image_latent_nodes.py
+++ b/videohelpersuite/image_latent_nodes.py
@@ -261,6 +261,7 @@ class SelectEveryNthLatent:
                 "required": {
                     "latents": ("LATENT",),
                     "select_every_nth": ("INT", {"default": 1, "min": 1, "max": BIGMAX, "step": 1}),
+                    "skip_first_latents": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                 },
             }
     
@@ -270,8 +271,8 @@ class SelectEveryNthLatent:
     RETURN_NAMES = ("LATENT", "count",)
     FUNCTION = "select_latents"
 
-    def select_latents(self, latents: dict, select_every_nth: int):
-        sub_latents = latents.copy()["samples"][0::select_every_nth]
+    def select_latents(self, latents: dict, select_every_nth: int, skip_first_latents: int):
+        sub_latents = latents.copy()["samples"][skip_first_latents::select_every_nth]
         return ({"samples": sub_latents}, sub_latents.size(0))
     
 
@@ -282,6 +283,8 @@ class SelectEveryNthImage:
                 "required": {
                     "images": ("IMAGE",),
                     "select_every_nth": ("INT", {"default": 1, "min": 1, "max": BIGMAX, "step": 1}),
+                    "skip_first_images": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
+                    
                 },
             }
     
@@ -291,8 +294,8 @@ class SelectEveryNthImage:
     RETURN_NAMES = ("IMAGE", "count",)
     FUNCTION = "select_images"
 
-    def select_images(self, images: Tensor, select_every_nth: int):
-        sub_images = images[0::select_every_nth]
+    def select_images(self, images: Tensor, select_every_nth: int, skip_first_images: int):
+        sub_images = images[skip_first_images::select_every_nth]
         return (sub_images, sub_images.size(0))
     
 
@@ -303,6 +306,7 @@ class SelectEveryNthMask:
                 "required": {
                     "mask": ("MASK",),
                     "select_every_nth": ("INT", {"default": 1, "min": 1, "max": BIGMAX, "step": 1}),
+                    "skip_first_masks": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                 },
             }
     
@@ -312,8 +316,8 @@ class SelectEveryNthMask:
     RETURN_NAMES = ("MASK", "count",)
     FUNCTION = "select_masks"
 
-    def select_masks(self, mask: Tensor, select_every_nth: int):
-        sub_mask = mask[0::select_every_nth]
+    def select_masks(self, mask: Tensor, select_every_nth: int, skip_first_masks: int):
+        sub_mask = mask[skip_first_masks::select_every_nth]
         return (sub_mask, sub_mask.size(0))
 
 

--- a/videohelpersuite/load_images_nodes.py
+++ b/videohelpersuite/load_images_nodes.py
@@ -139,6 +139,7 @@ class LoadImagesFromDirectoryUpload:
         }
     
     RETURN_TYPES = ("IMAGE", "MASK", "INT")
+    RETURN_NAMES = ("IMAGE", "MASK", "frame_count")
     FUNCTION = "load_images"
 
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
@@ -177,6 +178,7 @@ class LoadImagesFromDirectoryPath:
         }
     
     RETURN_TYPES = ("IMAGE", "MASK", "INT")
+    RETURN_NAMES = ("IMAGE", "MASK", "frame_count")
     FUNCTION = "load_images"
 
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -160,10 +160,10 @@ def load_video_cv(video: str, force_rate: int, force_size: str,
         if new_size[0] != width or new_size[1] != height:
             def rescale(frame):
                 s = torch.from_numpy(np.fromiter(frame, np.dtype((np.float32, (height, width, 3)))))
-                s = frame.movedim(-1,1).unsqueeze(0)
+                s = s.movedim(-1,1).unsqueeze(0)
                 s = common_upscale(s, new_size[0], new_size[1], "lanczos", "center")
                 return s.movedim(1,-1).squeeze(0).numpy()
-            gen = itertools.chain.from_iterable(map(rescale, batched(frames_per_batch)))
+            gen = itertools.chain.from_iterable(map(rescale, batched(gen, frames_per_batch)))
     else:
         new_size = width, height
     if vae is not None:
@@ -200,9 +200,9 @@ def load_video_cv(video: str, force_rate: int, force_size: str,
         "loaded_height": new_size[1],
     }
     if vae is None:
-        return (images, len(images), lazy_eval(audio), video_info)
+        return (images, len(images), lazy_eval(audio), video_info, None)
     else:
-        return ({"samples": images}, len(images), lazy_eval(audio), video_info)
+        return (None, len(images), lazy_eval(audio), video_info, {"samples": images})
 
 
 
@@ -283,8 +283,8 @@ class LoadVideoPath:
 
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
 
-    RETURN_TYPES = ("IMAGE", "INT", "VHS_AUDIO", "VHS_VIDEOINFO")
-    RETURN_NAMES = ("IMAGE", "frame_count", "audio", "video_info")
+    RETURN_TYPES = ("IMAGE", "INT", "VHS_AUDIO", "VHS_VIDEOINFO", "LATENT")
+    RETURN_NAMES = ("IMAGE", "frame_count", "audio", "video_info", "LATENT")
 
     FUNCTION = "load_video"
 

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -23,10 +23,12 @@ def is_gif(filename) -> bool:
 def target_size(width, height, force_size, custom_width, custom_height, downscale_ratio=8) -> tuple[int, int]:
     if force_size == "Disabled":
         pass
-    elif force_size == "Custom width":
+    elif force_size == "Custom Width":
         height *= custom_width/width
-    elif force_size == "Custom height":
+        width = custom_width
+    elif force_size == "Custom Height":
         width *= custom_height/height
+        height = custom_height
     else:
         width = custom_width
         height = custom_height

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -21,13 +21,15 @@ def is_gif(filename) -> bool:
 
 
 def target_size(width, height, force_size, custom_width, custom_height, downscale_ratio=8) -> tuple[int, int]:
-    if force_size == "Custom":
-        width = custom_width
-        height = custom_height
+    if force_size == "Disabled":
+        pass
     elif force_size == "Custom width":
         height *= custom_width/width
     elif force_size == "Custom height":
         width *= custom_height/height
+    else:
+        width = custom_width
+        height = custom_height
     width = int(width/downscale_ratio + 0.5) * downscale_ratio
     height = int(height/downscale_ratio + 0.5) * downscale_ratio
     return (width, height)
@@ -160,9 +162,9 @@ def load_video_cv(video: str, force_rate: int, force_size: str,
         if new_size[0] != width or new_size[1] != height:
             def rescale(frame):
                 s = torch.from_numpy(np.fromiter(frame, np.dtype((np.float32, (height, width, 3)))))
-                s = s.movedim(-1,1).unsqueeze(0)
+                s = s.movedim(-1,1)
                 s = common_upscale(s, new_size[0], new_size[1], "lanczos", "center")
-                return s.movedim(1,-1).squeeze(0).numpy()
+                return s.movedim(1,-1).numpy()
             gen = itertools.chain.from_iterable(map(rescale, batched(gen, frames_per_batch)))
     else:
         new_size = width, height

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -546,6 +546,9 @@ class VideoCombine:
                 "frame_rate": frame_rate,
             }
         ]
+        if num_frames == 1 and 'png' in format and '%03d' in file:
+            previews[0]['format'] = 'image/png'
+            previews[0]['filename'] = file.replace('%03d', '001')
         return {"ui": {"gifs": previews}, "result": ((save_output, output_files),)}
     @classmethod
     def VALIDATE_INPUTS(self, format, **kwargs):

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -543,6 +543,7 @@ class VideoCombine:
                 "subfolder": subfolder,
                 "type": "output" if save_output else "temp",
                 "format": format,
+                "frame_rate": frame_rate,
             }
         ]
         return {"ui": {"gifs": previews}, "result": ((save_output, output_files),)}

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -253,7 +253,8 @@ class VideoCombine:
 
         if isinstance(images, torch.Tensor) and images.size(0) == 0:
             return ("",)
-        pbar = ProgressBar(len(images))
+        num_frames = len(images)
+        pbar = ProgressBar(num_frames)
 
         first_image = images[0]
         # get output information
@@ -388,7 +389,7 @@ class VideoCombine:
             else:
                 dimensions = f"{first_image.shape[1]}x{first_image.shape[0]}"
             if loop_count > 0:
-                loop_args = ["-vf", "loop=loop=" + str(loop_count)+":size=" + str(len(images))]
+                loop_args = ["-vf", "loop=loop=" + str(loop_count)+":size=" + str(num_frames)]
             else:
                 loop_args = []
             if pingpong:
@@ -409,10 +410,6 @@ class VideoCombine:
                     i_pix_fmt = 'rgb24'
             file = f"{filename}_{counter:05}.{video_format['extension']}"
             file_path = os.path.join(full_output_folder, file)
-            if loop_count > 0:
-                loop_args = ["-vf", "loop=loop=" + str(loop_count)+":size=" + str(len(images))]
-            else:
-                loop_args = []
             bitrate_arg = []
             bitrate = video_format.get('bitrate')
             if bitrate is not None:

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -64,7 +64,7 @@ async def view_video(request):
             for path in valid_images:
                 f.write("file '" + os.path.abspath(path) + "'\n")
                 f.write("duration 0.125\n")
-        in_args = ["-framerate", str(frame_rate), "-safe", "0", "-i", concat_file]
+        in_args = ["-safe", "0", "-i", concat_file]
     else:
         in_args = ["-an", "-i", file]
         if '%' in file:

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -48,6 +48,7 @@ async def view_video(request):
             if not os.path.isfile(file) and not validate_sequence(file):
                     return web.Response(status=404)
 
+    frame_rate = query.get('frame_rate', 8)
     if query.get('format', 'video') == "folder":
         #Check that folder contains some valid image file, get it's extension
         #ffmpeg seems to not support list globs, so support for mixed extensions seems unfeasible
@@ -63,9 +64,11 @@ async def view_video(request):
             for path in valid_images:
                 f.write("file '" + os.path.abspath(path) + "'\n")
                 f.write("duration 0.125\n")
-        in_args = ["-safe", "0", "-i", concat_file]
+        in_args = ["-framerate", str(frame_rate), "-safe", "0", "-i", concat_file]
     else:
         in_args = ["-an", "-i", file]
+        if '%' in file:
+            in_args = ['-framerate', str(frame_rate)] + in_args
 
     args = [ffmpeg_path, "-v", "error"] + in_args
     vfilters = []

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -174,6 +174,40 @@ async function uploadFile(file) {
         alert(error);
     }
 }
+function addVAEOutputToggle(nodeType) {
+    chainCallback(nodeType.prototype, "onNodeCreated", function() {
+        chainCallback(this, "onConnectInput", function(islot, otype, o, onode, oslot) {
+            if (islot == 1) {
+                this.disconnectOutput(0)
+                this.outputs[0].name = 'LATENT'
+                this.outputs[0].type = 'LATENT'
+            }
+        });
+        chainCallback(this, "disconnectInput", function(slot) {
+            if (slot == 1) {
+                this.disconnectOutput(0)
+                this.outputs[0].name = "IMAGE"
+                this.outputs[0].type = "IMAGE"
+            }
+        })
+    })
+}
+function addVAEInputToggle(nodeType) {
+    chainCallback(nodeType.prototype, "onNodeCreated", function() {
+        chainCallback(this, "onConnectInput", function(islot, otype, o, onode, oslot) {
+            if (islot == 3) {
+                this.disconnectInput(0)
+                this.inputs[0].type = 'LATENT'
+            }
+        });
+        chainCallback(this, "disconnectInput", function(slot) {
+            if (slot == 3) {
+                this.disconnectInput(0)
+                this.inputs[0].type = "IMAGE"
+            }
+        })
+    })
+}
 
 function addDateFormatting(nodeType, field, timestamp_widget = false) {
     chainCallback(nodeType.prototype, "onNodeCreated", function() {
@@ -964,6 +998,7 @@ app.registerExtension({
                 });
             });
             addLoadVideoCommon(nodeType, nodeData);
+            addVAEOutputToggle(nodeType, nodeData);
         } else if (nodeData?.name == "VHS_LoadAudioUpload") {
             addUploadWidget(nodeType, nodeData, "audio", "audio");
   
@@ -983,6 +1018,7 @@ app.registerExtension({
                 });
             });
             addLoadVideoCommon(nodeType, nodeData);
+            addVAEOutputToggle(nodeType, nodeData);
         } else if (nodeData?.name == "VHS_VideoCombine") {
             addDateFormatting(nodeType, "filename_prefix");
             chainCallback(nodeType.prototype, "onExecuted", function(message) {
@@ -993,6 +1029,7 @@ app.registerExtension({
             addVideoPreview(nodeType);
             addPreviewOptions(nodeType);
             addFormatWidgets(nodeType);
+            addVAEInputToggle(nodeType, nodeData)
 
             //Hide the information passing 'gif' output
             //TODO: check how this is implemented for save image

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -572,6 +572,9 @@ function addPreviewOptions(nodeType) {
         if (previewWidget.videoEl?.hidden == false && previewWidget.videoEl.src) {
             //Use full quality video
             url = api.apiURL('/view?' + new URLSearchParams(previewWidget.value.params));
+            //Workaround for 16bit png: Just do first frame
+            url = url.replace('%2503d', '001')
+            console.log(url)
         } else if (previewWidget.imgEl?.hidden == false && previewWidget.imgEl.src) {
             url = previewWidget.imgEl.src;
             url = new URL(url);

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -218,10 +218,23 @@ function addVAEInputToggle(nodeType, nodeData) {
     chainCallback(nodeType.prototype, "onConnectionsChange", function(contype, slot, iscon, linf) {
         if (contype == LiteGraph.INPUT && slot == 3) {
             if (iscon && linf) {
-                this.disconnectInput(0);
+                if (this.linkTimeout) {
+                    clearTimeout(this.linkTimeout)
+                    this.linkTimeout = false
+                } else if (this.inputs[0].type == "IMAGE") {
+                    this.linkTimeout = setTimeout(() => {
+                        this.linkTimeout = false
+                        this.disconnectInput(0);
+                    }, 50)
+                }
                 this.inputs[0].type = 'LATENT';
             } else {
-                this.disconnectInput(0);
+                if (this.inputs[0].type == "LATENT") {
+                    this.linkTimeout = setTimeout(() => {
+                        this.linkTimeout = false
+                        this.disconnectInput(0);
+                    }, 50)
+                }
                 this.inputs[0].type = "IMAGE";
             }
         }


### PR DESCRIPTION
The Load Video and Video Combine nodes now take an optional VAE input. When a vae input is supplied, they will either  input or output latents instead of images. This provides substantial savings to cpu RAM.
- Known downside:  Video Combine will 'execute' even when images are not provided as an input, and no longer performs input validation on the images input since it is now marked as optional.

Additionally, output previews for image sequences (16bitpng) will now properly respect frame rate, context menu options for image sequence outputs will return the first frame instead of an error, and #220 is merged, which adds a skip_first option to the SelectEveryNth nodes.