### PR TITLE
Remove is_integer check

### DIFF
--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -62,7 +62,7 @@ def cv_frame_generator(video, force_rate, frame_load_cap, skip_first_frames,
         target_frame_time = 1/force_rate
 
     yield (width, height, fps, duration, total_frames, target_frame_time)
-    if total_frames and total_frames.is_integer():
+    if total_frames > 0:
         if force_rate != 0:
             yieldable_frames = int(total_frames / fps * force_rate)
         else:


### PR DESCRIPTION
is_integer was only added in python 3.12, so the line caused issues for any newer version of python. Upon further reveiw, the call serves no purpose as total frames is already cast as int and, if any error state could exist as a non integer value (inf or nan) it would have already thrown an error. Instead a check is simply performed to verify that total_frames is greater than 0

Resolves #265