### PR TITLE
Fix mistaken ffmpeg path.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-videohelpersuite"
 description = "Nodes related to video workflows"
-version = "1.3.4"
+version = "1.3.5"
 license = { file = "LICENSE" }
 dependencies = ["opencv-python", "imageio-ffmpeg"]
 

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -75,7 +75,7 @@ async def view_video(request):
     #breaks skip_first frames if this default is ever actually needed
     base_fps = 30
     try:
-        res = subprocess.run(['ffmpeg'] + in_args + ['-t', '0', '-f', 'null', '-'],
+        res = subprocess.run([ffmpeg_path] + in_args + ['-t', '0', '-f', 'null', '-'],
                              capture_output=True, check=True)
         match = re.search(': Video: (\\w+) .+, (\\d+) fps,', res.stderr.decode('utf-8'))
         if match:


### PR DESCRIPTION
As a workaround to displaying transparent videos and to support correct audio synchronization in advanced previews, a initial prepass is performed to query information on the video file. This prepass mistakenly used a hardcoded `ffmpeg` instead of the proper `ffmpeg_path`