### PR TITLE
Workaround for scaling issues

### DIFF
--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -191,8 +191,9 @@ function initHelpDOM() {
         const transform = ctx.getTransform();
         const scale = app.canvas.ds.scale;//gets the litegraph zoom
         //calculate coordinates with account for browser zoom
-        const x = transform.e*scale/transform.a;
-        const y = transform.f*scale/transform.a;
+        const bcr = app.canvas.canvas.getBoundingClientRect()
+        const x = transform.e*scale/transform.a + bcr.x;
+        const y = transform.f*scale/transform.a + bcr.y;
         //TODO: text reflows at low zoom. investigate alternatives
         Object.assign(parentDOM.style, {
             left: (x+(n.pos[0] + n.size[0]+15)*scale) + "px",


### PR DESCRIPTION
The new side and menu bar provides an additional offset which must be accounted for in the position calculations for the helpDOM

There is likely a cleaner way to obtain either the offset itself, or a context transform with the offset included, but the only means I've found so far from my digging is to pull the bounding client rect from the canvas element itself