### PR TITLE
Fix Prune Outputs when current dir isn't ComfyUI

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -733,7 +733,8 @@ class PruneOutputs:
         if options in ["All"]:
             delete_list.append(filenames[1][-1])
 
-        output_dirs = [os.path.abspath("output"), os.path.abspath("temp")]
+        output_dirs = [folder_paths.get_output_directory(),
+                       folder_paths.get_temp_directory()]
         for file in delete_list:
             #Check that path is actually an output directory
             if (os.path.commonpath([output_dirs[0], file]) != output_dirs[0]) \


### PR DESCRIPTION
The existing prune outputs code naively presumed that the current directory was the ComfyUI base dir when determining the location of the output and temp directories. When running ComfyUI through the windows portable release, this is not the case.

This is trivially solved by using the methods provided in folder paths to get the output and temp directories.