### PR TITLE
Remove args indexing from vae decoding

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -287,7 +287,8 @@ class VideoCombine:
             #repush first_image
             images = itertools.chain([first_image], images)
             #A single image has 3 dimensions. Discard higher dimensions
-            first_image = first_image[*([0]*(len(first_image.shape)-3))]
+            while len(first_image.shape) > 3:
+                first_image = first_image[0]
         else:
             first_image = images[0]
             images = iter(images)


### PR DESCRIPTION
Newer versions of python support indexing multiple dimensions by prefixing a variable with an aseterisk similar to how it can be used for functions. This was utilized to discard higher dimensions (excess frames) produced by vae output when using temporal vae, but causes syntax errors with older versions of python. This is fixed by using a while loop instead.