### PR TITLE
Refactor decoding format, escape unconvertable

### DIFF
--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -13,7 +13,8 @@ from comfy.utils import common_upscale, ProgressBar
 from comfy.k_diffusion.utils import FolderOfImages
 from .logger import logger
 from .utils import BIGMAX, DIMMAX, calculate_file_hash, get_sorted_dir_files_from_directory,\
-        lazy_get_audio, hash_path, validate_path, strip_path, try_download_video, is_url, imageOrLatent, ffmpeg_path
+        lazy_get_audio, hash_path, validate_path, strip_path, try_download_video,  \
+        is_url, imageOrLatent, ffmpeg_path, ENCODE_ARGS
 
 
 video_extensions = ['webm', 'mp4', 'mkv', 'gif', 'mov']
@@ -146,8 +147,8 @@ def ffmpeg_frame_generator(video, force_rate, frame_load_cap, start_time,
                                     stderr=subprocess.PIPE,check=True)
     except subprocess.CalledProcessError as e:
         raise Exception("An error occurred in the ffmepg subprocess:\n" \
-                + e.stderr.decode("utf-8"))
-    lines = dummy_res.stderr.decode("utf-8")
+                + e.stderr.decode(*ENCODE_ARGS))
+    lines = dummy_res.stderr.decode(*ENCODE_ARGS)
     for line in lines.split('\n'):
         match = re.search(", ([1-9]|\\d{2,})x(\\d+).*, ([\\d\\.]+) fps", line)
         if match is not None:
@@ -226,7 +227,7 @@ def ffmpeg_frame_generator(video, force_rate, frame_load_cap, start_time,
                     current_offset = 0
     except BrokenPipeError as e:
         raise Exception("An error occured in the ffmpeg subprocess:\n" \
-                + proc.stderr.read().decode("utf-8"))
+                + proc.stderr.read().decode(*ENCODE_ARGS))
     if meta_batch is not None:
         meta_batch.inputs.pop(unique_id)
         meta_batch.has_closed_inputs = True

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -4,7 +4,8 @@ import os
 import time
 import subprocess
 import re
-from .utils import is_url, get_sorted_dir_files_from_directory, ffmpeg_path, validate_sequence, is_safe_path, strip_path, try_download_video
+from .utils import is_url, get_sorted_dir_files_from_directory, ffmpeg_path, \
+        validate_sequence, is_safe_path, strip_path, try_download_video, ENCODE_ARGS
 from comfy.k_diffusion.utils import FolderOfImages
 
 web = server.web
@@ -78,7 +79,7 @@ async def view_video(request):
     try:
         res = subprocess.run([ffmpeg_path] + in_args + ['-t', '0', '-f', 'null', '-'],
                              capture_output=True, check=True)
-        match = re.search(': Video: (\\w+) .+, (\\d+) fps,', res.stderr.decode('utf-8'))
+        match = re.search(': Video: (\\w+) .+, (\\d+) fps,', res.stderr.decode(*ENCODE_ARGS))
         if match:
             base_fps = float(match.group(2))
             if match.group(1) == 'vp9':
@@ -86,7 +87,7 @@ async def view_video(request):
                 in_args = ['-c:v', 'libvpx-vp9'] + in_args
     except subprocess.CalledProcessError as e:
         print("An error occurred in the ffmpeg prepass:\n" \
-                + e.stderr.decode("utf-8"))
+                + e.stderr.decode(*ENCODE_ARGS))
     vfilters = []
     target_rate = float(query.get('force_rate', 0)) or base_fps
     modified_rate = target_rate / float(query.get('select_every_nth',1))

--- a/videohelpersuite/utils.py
+++ b/videohelpersuite/utils.py
@@ -18,10 +18,12 @@ BIGMAX = (2**53-1)
 
 DIMMAX = 8192
 
+ENCODE_ARGS = ("utf-8", 'backslashreplace')
+
 def ffmpeg_suitability(path):
     try:
         version = subprocess.run([path, "-version"], check=True,
-                                 capture_output=True).stdout.decode("utf-8")
+                                 capture_output=True).stdout.decode(*ENCODE_ARGS)
     except:
         return 0
     score = 0
@@ -98,10 +100,10 @@ def try_download_video(url):
                               "-P", folder_paths.get_temp_directory(), url],
                              capture_output=True, check=True)
         #strip newline
-        file = res.stdout.decode('utf-8')[:-1]
+        file = res.stdout.decode(*ENCODE_ARGS)[:-1]
     except subprocess.CalledProcessError as e:
         raise Exception("An error occurred in the yt-dl process:\n" \
-                + e.stderr.decode("utf-8"))
+                + e.stderr.decode(*ENCODE_ARGS))
         file = None
     download_history[url] = file
     return file
@@ -198,10 +200,10 @@ def get_audio(file, start_time=0, duration=0):
         res =  subprocess.run(args + ["-f", "f32le", "-"],
                               capture_output=True, check=True)
         audio = torch.frombuffer(bytearray(res.stdout), dtype=torch.float32)
-        match = re.search(', (\\d+) Hz, (\\w+), ',res.stderr.decode('utf-8'))
+        match = re.search(', (\\d+) Hz, (\\w+), ',res.stderr.decode(*ENCODE_ARGS))
     except subprocess.CalledProcessError as e:
         raise Exception(f"VHS failed to extract audio from {file}:\n" \
-                + e.stderr.decode("utf-8"))
+                + e.stderr.decode(*ENCODE_ARGS))
     if match:
         ar = int(match.group(1))
         #NOTE: Just throwing an error for other channel types right now


### PR DESCRIPTION
I've had underlying concern for a while now that universally using utf-8 isn't correct because it doesn't respect locale and this serves as fairly strong confirmation. From a little bit of digging, checking seems as simple as calling `locale.getencoding()`, but the documentation claims that this is ANSI for windows (meaning changing it would affect the majority of users). As a result, I've refactored out all the string decoding to use a common variable and set it to display an escaped version of any unconvertable characters, but am leaving the format as utf-8 until I have further information.

See #324