### PR TITLE
Fix video preview streaming

### DIFF
--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -140,7 +140,7 @@ async def view_video(request):
                 resp.headers["Content-Disposition"] = f"filename=\"{filename}\""
                 await resp.prepare(request)
                 while True:
-                    bytes_read = proc.stdout.read()
+                    bytes_read = proc.stdout.read(2**13)
                     if bytes_read is None:
                         #TODO: check for timeout here
                         time.sleep(.1)


### PR DESCRIPTION
Managed to track down the issue stopping video previews from properly streaming after some exasperated digging. 

As this resolves the primary performance blocker, VHS_AdvancedPreviews can now be made enabled by default in a future update.