### PR TITLE
Latent video preview support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,6 +2,7 @@ from .videohelpersuite.nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPI
 import folder_paths
 from .videohelpersuite.server import server
 from .videohelpersuite import documentation
+from .videohelpersuite import latent_preview
 
 WEB_DIRECTORY = "./web"
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]

--- a/videohelpersuite/latent_preview.py
+++ b/videohelpersuite/latent_preview.py
@@ -1,0 +1,104 @@
+import asyncio
+import subprocess
+from PIL import Image
+
+import latent_preview
+import server
+serv = server.PromptServer.instance
+
+web = server.web
+
+class PreviewInstance:
+    def __init__(self):
+        self.has_data = asyncio.Event()
+        self.preview_at = 0
+        self.data  = []
+        self.closed = False
+
+#TODO sid?
+preview_instances = {}
+def get_instance(node_id):
+    if node_id not in preview_instances:
+        preview_instances[node_id] = PreviewInstance()
+    return preview_instances[node_id]
+
+@serv.routes.get("/vhs/latentvideopreview")
+async def latent_video_preview(request):
+    query = request.rel_url.query
+    if 'node_id' in query:
+        instance = get_instance(query['node_id'])
+    elif len(preview_instances) > 0:
+        instance = next(preview_instances.values())
+    else:
+        return web.response(status=400)
+
+    rate = 8.0
+    args = ['ffmpeg','-v', 'error', '-f', 'rawvideo', '-pix_fmt', 'rgb24', '-s', '512x512', '-r', str(rate), '-i', '-']
+    args += ['-c:v', 'libvpx-vp9','-deadline', 'realtime', '-cpu-used', '8', '-f', 'webm', '-']
+    try:
+        proc = await asyncio.create_subprocess_exec(*args, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+        try:
+            resp = web.StreamResponse()
+            resp.content_type = 'video/webm'
+            await resp.prepare(request)
+            async def read_loop():
+                delay = asyncio.sleep(.1)
+                while data := await proc.stdout.read(2**20):
+                    await asyncio.gather(delay, resp.write(data))
+                    delay = asyncio.sleep(.1)
+            async def write_loop():
+                await instance.has_data.wait()
+                preview_at = 0
+                delay = asyncio.create_task(asyncio.sleep(1/rate))
+                frame_at = 0
+                while True:
+                    proc.stdin.write(instance.data[frame_at])
+                    frame_at = (frame_at + 1) % len(instance.data)
+                    if frame_at == instance.preview_at:
+                        if not instance.has_data.is_set() and instance.closed:
+                            proc.stdin.close()
+                            delay.close()
+                            return
+                        await instance.has_data.wait()
+                        instance.has_data.clear()
+                    await asyncio.gather(proc.stdin.drain(), delay)
+                    delay = asyncio.create_task(asyncio.sleep(1/rate))
+
+            await asyncio.gather(read_loop(), write_loop())
+            await proc.wait()
+        except (ConnectionResetError, ConnectionError) as e:
+            pass
+        finally:
+            print('ded')
+            #Kill ffmpeg before the pipe is closed
+            proc.kill()
+
+    except BrokenPipeError as e:
+        pass
+    return resp
+
+orig_get_previewer = latent_preview.get_previewer
+def get_latent_video_previewer(device, latent_format):
+    node_id = serv.last_node_id
+    serv.send_sync('VHS_latentpreview', node_id)
+    previewer = orig_get_previewer(device, latent_format)
+    if not hasattr(previewer, "decode_latent_to_preview"):
+        return None
+    original_decode = previewer.decode_latent_to_preview
+    def wrapped_decode(_, x0):
+        inst = get_instance(node_id)
+        num_images = x0.size(0)
+        if len(inst.data) != num_images:
+            inst.data = [b''] * num_images
+        for i in range(num_images):
+            sub_image = original_decode(x0[i:i+1])
+            if sub_image.size[0] != 512 or sub_image.size[1] != 512:
+                sub_image = sub_image.resize((512, 512),
+                                             Image.Resampling.NEAREST)
+            inst.data[i] = sub_image.tobytes()
+        inst.has_data.set()
+        return None
+    previewer.decode_latent_to_preview_image = wrapped_decode
+    return previewer
+latent_preview.get_previewer = get_latent_video_previewer
+

--- a/videohelpersuite/latent_preview.py
+++ b/videohelpersuite/latent_preview.py
@@ -9,37 +9,32 @@ import latent_preview
 import server
 serv = server.PromptServer.instance
 
-orig_get_previewer = latent_preview.get_previewer
-def get_latent_video_previewer(device, latent_format):
-    node_id = serv.last_node_id
-    previewer = orig_get_previewer(device, latent_format)
-    if not hasattr(previewer, "decode_latent_to_preview"):
-        return None
-    first_preview = True
-    serv.send_sync('VHS_latentpreview', node_id)
-    last_time = 0
-    c_index = 0
-    original_decode = previewer.decode_latent_to_preview
-    def wrapped_decode(_, x0):
-        nonlocal first_preview, last_time, c_index
+
+class WrappedPreviewer(latent_preview.LatentPreviewer):
+    def __init__(self, dltp):
+        self.first_preview = True
+        self.last_time = 0
+        self.c_index = 0
+        self.decode_latent_to_preview = dltp
+    def decode_latent_to_preview_image(self, preview_format, x0):
         if x0.ndim == 5:
             #Keep batch major
             x0 = x0.movedim(2,1)
             x0 = x0.reshape((-1,)+x0.shape[-3:])
         num_images = x0.size(0)
         new_time = time.time()
-        num_previews = int((new_time - last_time) * 8)
-        last_time = last_time + num_previews/8
+        num_previews = int((new_time - self.last_time) * 8)
+        self.last_time = self.last_time + num_previews/8
         if num_previews > num_images:
             num_previews = num_images
-        if first_preview:
-            first_preview = False
+        if self.first_preview:
+            self.first_preview = False
             serv.send_sync('VHS_latentpreview', num_images)
         for _ in range(num_previews):
-            sub_image = original_decode(x0[c_index:c_index+1])
+            sub_image = self.decode_latent_to_preview(x0[self.c_index:self.c_index+1])
             message = io.BytesIO()
             message.write(b'\x00\x00\x00\x01\x00\x00\x00\x01')
-            message.write(c_index.to_bytes(length=4))
+            message.write(self.c_index.to_bytes(length=4))
             if sub_image.size[0] > 512 or sub_image.size[1] > 512:
                 if sub_image.size[0] > sub_image.size[1]:
                     resize = (512, int(sub_image.size[1]*512/sub_image.size[0]))
@@ -50,10 +45,19 @@ def get_latent_video_previewer(device, latent_format):
             sub_image.save(message, format="JPEG", quality=95, compress_level=1)
             serv.send_sync(server.BinaryEventTypes.PREVIEW_IMAGE,
                            message.getvalue(), serv.client_id)
-            c_index = (c_index +1) % num_images
-        return None
-    previewer.decode_latent_to_preview_image = wrapped_decode
-    return previewer
+            self.c_index = (self.c_index +1) % num_images
+
+orig_get_previewer = latent_preview.get_previewer
+def get_latent_video_previewer(device, latent_format):
+    node_id = serv.last_node_id
+    previewer = orig_get_previewer(device, latent_format)
+    try:
+        prev_setting = next(serv.prompt_queue.currently_running.values().__iter__())[3] \
+                ['extra_pnginfo']['workflow']['extra'].get('VHS_latentpreview', False)
+    except:
+        #For safety since there's lots of keys, any of which can fail
+        prev_setting = False
+    if not prev_setting or not hasattr(previewer, "decode_latent_to_preview"):
+        return previewer
+    return WrappedPreviewer(previewer.decode_latent_to_preview)
 latent_preview.get_previewer = get_latent_video_previewer
-
-

--- a/videohelpersuite/latent_preview.py
+++ b/videohelpersuite/latent_preview.py
@@ -1,109 +1,54 @@
 import asyncio
 import subprocess
 from PIL import Image
+import time
+import math
+import io
 
 import latent_preview
 import server
 serv = server.PromptServer.instance
 
-web = server.web
-
-class PreviewInstance:
-    def __init__(self):
-        self.has_data = asyncio.Event()
-        self.preview_at = 0
-        self.data  = []
-        self.closed = False
-
-#TODO sid?
-preview_instances = {}
-def get_instance(node_id):
-    if node_id not in preview_instances:
-        preview_instances[node_id] = PreviewInstance()
-    return preview_instances[node_id]
-
-@serv.routes.get("/vhs/latentvideopreview")
-async def latent_video_preview(request):
-    query = request.rel_url.query
-    if 'node_id' in query:
-        instance = get_instance(query['node_id'])
-    elif len(preview_instances) > 0:
-        instance = next(preview_instances.values())
-    else:
-        return web.response(status=400)
-
-    rate = 8.0
-    args = ['ffmpeg','-v', 'error', '-f', 'rawvideo', '-pix_fmt', 'rgb24', '-s', '512x512', '-r', str(rate), '-i', '-']
-    args += ['-c:v', 'libvpx-vp9','-deadline', 'realtime', '-cpu-used', '8', '-f', 'webm', '-']
-    try:
-        proc = await asyncio.create_subprocess_exec(*args, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
-        try:
-            resp = web.StreamResponse()
-            resp.content_type = 'video/webm'
-            await resp.prepare(request)
-            async def read_loop():
-                delay = asyncio.sleep(.1)
-                while data := await proc.stdout.read(2**20):
-                    await asyncio.gather(delay, resp.write(data))
-                    delay = asyncio.sleep(.1)
-            async def write_loop():
-                await instance.has_data.wait()
-                preview_at = 0
-                delay = asyncio.create_task(asyncio.sleep(1/rate))
-                frame_at = 0
-                while True:
-                    proc.stdin.write(instance.data[frame_at])
-                    frame_at = (frame_at + 1) % len(instance.data)
-                    if frame_at == instance.preview_at:
-                        if not instance.has_data.is_set() and instance.closed:
-                            proc.stdin.close()
-                            delay.close()
-                            return
-                        if not query.get('repeat_stale', False):
-                            await instance.has_data.wait()
-                            instance.has_data.clear()
-                    await asyncio.gather(proc.stdin.drain(), delay)
-                    delay = asyncio.create_task(asyncio.sleep(1/rate))
-
-            await asyncio.gather(read_loop(), write_loop())
-            await proc.wait()
-        except (ConnectionResetError, ConnectionError) as e:
-            pass
-        finally:
-            print('ded')
-            #Kill ffmpeg before the pipe is closed
-            proc.kill()
-
-    except BrokenPipeError as e:
-        pass
-    return resp
-
 orig_get_previewer = latent_preview.get_previewer
 def get_latent_video_previewer(device, latent_format):
     node_id = serv.last_node_id
-    serv.send_sync('VHS_latentpreview', node_id)
     previewer = orig_get_previewer(device, latent_format)
     if not hasattr(previewer, "decode_latent_to_preview"):
         return None
+    first_preview = True
+    serv.send_sync('VHS_latentpreview', node_id)
+    last_time = time.time()
+    c_index = 0
     original_decode = previewer.decode_latent_to_preview
     def wrapped_decode(_, x0):
-        inst = get_instance(node_id)
+        nonlocal first_preview, last_time, c_index
+        #inst = get_instance(node_id)
         if x0.ndim == 5:
             #Keep batch major
             x0 = x0.movedim(2,1)
             x0 = x0.reshape((-1,)+x0.shape[-3:])
         num_images = x0.size(0)
-        if len(inst.data) != num_images:
-            inst.data = [b''] * num_images
-        for i in range(num_images):
-            sub_image = original_decode(x0[i:i+1])
+        new_time = time.time()
+        num_previews = min(math.ceil((new_time - last_time) * 8), num_images)
+        if first_preview:
+            first_preview = False
+            serv.send_sync('VHS_latentpreview', num_images)
+        last_time = new_time
+        for _ in range(num_previews):
+            sub_image = original_decode(x0[c_index:c_index+1])
+            message = io.BytesIO()
+            message.write(b'\x00\x00\x00\x01\x00\x00\x00\x01')
+            message.write(c_index.to_bytes(length=4))
             if sub_image.size[0] != 512 or sub_image.size[1] != 512:
                 sub_image = sub_image.resize((512, 512),
                                              Image.Resampling.NEAREST)
-            inst.data[i] = sub_image.tobytes()
-        inst.has_data.set()
+            sub_image.save(message, format="JPEG", quality=95, compress_level=1)
+            serv.send_sync(server.BinaryEventTypes.PREVIEW_IMAGE,
+                           message.getvalue(), serv.client_id)
+            c_index = (c_index +1) % num_images
         return None
     previewer.decode_latent_to_preview_image = wrapped_decode
     return previewer
 latent_preview.get_previewer = get_latent_video_previewer
+
 

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -5,12 +5,10 @@ import subprocess
 import re
 
 import asyncio
-from PIL import Image
 
 from .utils import is_url, get_sorted_dir_files_from_directory, ffmpeg_path, \
         validate_sequence, is_safe_path, strip_path, try_download_video, ENCODE_ARGS
 from comfy.k_diffusion.utils import FolderOfImages
-import latent_preview
 
 
 web = server.web
@@ -194,72 +192,3 @@ async def get_path(request):
             pass
 
     return web.json_response(valid_items)
-
-has_preview_data = asyncio.Event()
-preview_at = 0
-preview_data = []
-
-@server.PromptServer.instance.routes.get("/vhs/latentvideopreview")
-async def latent_video_preview(request):
-    rate = 8.0
-    args = ['ffmpeg','-v', 'error', '-f', 'rawvideo', '-pix_fmt', 'rgb24', '-s', '512x512', '-r', str(rate), '-i', '-']
-    args += ['-c:v', 'libvpx-vp9','-deadline', 'realtime', '-cpu-used', '8', '-f', 'webm', '-']
-    try:
-        proc = await asyncio.create_subprocess_exec(*args, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
-        try:
-            resp = web.StreamResponse()
-            resp.content_type = 'video/webm'
-            await resp.prepare(request)
-            async def read_loop():
-                delay = asyncio.sleep(.1)
-                while data := await proc.stdout.read(2**20):
-                    await asyncio.gather(delay, resp.write(data))
-                    delay = asyncio.sleep(.1)
-            async def write_loop():
-                await has_preview_data.wait()
-                preview_at = 0
-                delay = asyncio.create_task(asyncio.sleep(1/rate))
-                frame_at = 0
-                while True:
-                    proc.stdin.write(preview_data[frame_at])
-                    frame_at = (frame_at + 1) % len(preview_data)
-                    if frame_at == preview_at:
-                        await has_preview_data.wait()
-                        has_preview_data.clear()
-                    await asyncio.gather(proc.stdin.drain(), delay)
-                    delay = asyncio.create_task(asyncio.sleep(1/rate))
-
-            await asyncio.gather(read_loop(), write_loop())
-            await proc.wait()
-        except (ConnectionResetError, ConnectionError) as e:
-            pass
-        finally:
-            print('ded')
-            #Kill ffmpeg before the pipe is closed
-            proc.kill()
-
-    except BrokenPipeError as e:
-        pass
-    return resp
-
-orig_get_previewer = latent_preview.get_previewer
-def get_latent_video_previewer(device, latent_format):
-    previewer = orig_get_previewer(device, latent_format)
-    original_decode = previewer.decode_latent_to_preview
-    def wrapped_decode(x0):
-        global preview_data
-        num_images = x0.size(0)
-        if len(preview_data) != num_images:
-            preview_data = [b''] * num_images
-        for i in range(num_images):
-            sub_image = original_decode(x0[i:i+1])
-            if sub_image.size[0] != 512 or sub_image.size[1] != 512:
-                sub_image = sub_image.resize((512, 512),
-                                             Image.Resampling.NEAREST)
-            preview_data[i] = sub_image.tobytes()
-
-        has_preview_data.set()
-        return sub_image
-    previewer.decode_latent_to_preview = wrapped_decode
-    return previewer
-latent_preview.get_previewer = get_latent_video_previewer

--- a/videohelpersuite/utils.py
+++ b/videohelpersuite/utils.py
@@ -6,6 +6,7 @@ import subprocess
 import re
 from collections.abc import Mapping
 from typing import Union
+import functools
 import torch
 from torch import Tensor
 
@@ -387,3 +388,11 @@ def select_indexes_from_str(input_obj: Union[Tensor, list], indexes: str, err_if
     if err_if_empty and len(real_idxs) == 0:
         raise Exception(f"Nothing was selected based on indexes found in '{indexes}'.")
     return select_indexes(input_obj, real_idxs)
+
+def hook(obj, attr):
+    def dec(f):
+        f = functools.update_wrapper(f, getattr(obj,attr))
+        setattr(obj,attr,f)
+        return f
+    return dec
+

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1315,11 +1315,24 @@ app.ui.settings.addSetting({
     type: "boolean",
     defaultValue: false,
 });
+let latentPreviewNodes = new Set()
 app.ui.settings.addSetting({
     id: "VHS.LatentPreview",
     name: "🎥🅥🅗🅢 Display animated previews when sampling",
     type: "boolean",
     defaultValue: false,
+    onChange(value) {
+        if (!value) {
+            //Remove any previewWidgets
+            for (let n of latentPreviewNodes) {
+                let i = n?.widgets?.findIndex((w) => w.name == 'videopreview')
+                if (i >= 0) {
+                    n.widgets.splice(i,1)[0].onRemove()
+                }
+            }
+            latentPreviewNodes = new Set()
+        }
+    },
 });
 
 app.registerExtension({
@@ -1637,6 +1650,7 @@ api.addEventListener('VHS_latentpreview', ({ detail }) => {
     let previewNode = app.graph.getNodeById(id)
     let previewWidget = previewNode.widgets.find((w) => w.name == 'videopreview') ??
         _addVideoPreview(previewNode)
+    latentPreviewNodes.add(previewNode)
     previewWidget.videoEl.hidden = true
     previewWidget.imgEl.hidden = false
     for (let im of previewImages) {

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1334,6 +1334,20 @@ app.ui.settings.addSetting({
         }
     },
 });
+app.ui.settings.addSetting({
+    id: "VHS.LatentPreviewRate",
+    name: "🎥🅥🅗🅢 Playback keyframe rate.",
+    type: "boolean",
+      type: 'number',
+      attrs: {
+        min: 1,
+        step: 1,
+        max: 60
+      },
+      tooltip:
+        'When dragging and resizing nodes while holding shift they will be aligned to the grid, this controls the size of that grid.',
+    defaultValue: 8,
+});
 
 app.registerExtension({
     name: "VideoHelperSuite.Core",
@@ -1615,6 +1629,7 @@ app.registerExtension({
                 }
             }
             res.workflow.extra['VHS_latentpreview'] = app.ui.settings.getSettingValue("VHS.LatentPreview", false)
+            res.workflow.extra['VHS_latentpreviewrate'] = app.ui.settings.getSettingValue("VHS.LatentPreviewRate", 8)
             return res
         }
         app.graphToPrompt = graphToPrompt

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1318,13 +1318,8 @@ app.ui.settings.addSetting({
 app.ui.settings.addSetting({
     id: "VHS.LatentPreview",
     name: "🎥🅥🅗🅢 Display animated previews when sampling",
-    type: "combo",
-    defaultValue: 'Disabled',
-    options: (value) => [
-        {value: 'Disabled', text: 'Disabled', selected: value == 'Disabled'},
-        {value: 'Blocking', text: 'Blocking', selected: value == 'Blocking'},
-        {value: 'Continuous', text: 'Continuous', selected: value == 'Continuous'}
-    ]
+    type: "boolean",
+    defaultValue: false,
 });
 
 app.registerExtension({
@@ -1606,6 +1601,7 @@ app.registerExtension({
                     }
                 }
             }
+            res.workflow.extra['VHS_latentpreview'] = app.ui.settings.getSettingValue("VHS.LatentPreview", false)
             return res
         }
         app.graphToPrompt = graphToPrompt
@@ -1630,11 +1626,10 @@ app.registerExtension({
 let previewImages = []
 let animateInterval
 api.addEventListener('VHS_latentpreview', ({ detail }) => {
-    let setting = app.ui.settings.getSettingValue("VHS.LatentPreview", 'Disabled')
-    if (setting == 'Disabled') {
+    let setting = app.ui.settings.getSettingValue("VHS.LatentPreview", false)
+    if (!setting) {
         return
     }
-    let repeat = setting == 'Continuous'
     let id = app.runningNodeId
     if (id == null) {
         return

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1644,6 +1644,11 @@ api.addEventListener('VHS_latentpreview', ({ detail }) => {
         _addVideoPreview(previewNode)
     previewWidget.videoEl.hidden = true
     previewWidget.imgEl.hidden = false
+    for (let im of previewImages) {
+        if (im) {
+            URL.revokeObjectURL(im)
+        }
+    }
     previewImages = []
     previewImages.length = detail
     let displayIndex = 0

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1315,6 +1315,17 @@ app.ui.settings.addSetting({
     type: "boolean",
     defaultValue: false,
 });
+app.ui.settings.addSetting({
+    id: "VHS.LatentPreview",
+    name: "🎥🅥🅗🅢 Display animated previews when sampling",
+    type: "combo",
+    defaultValue: 'Disabled',
+    options: (value) => [
+        {value: 'Disabled', text: 'Disabled', selected: value == 'Disabled'},
+        {value: 'Blocking', text: 'Blocking', selected: value == 'Blocking'},
+        {value: 'Continuous', text: 'Continuous', selected: value == 'Continuous'}
+    ]
+});
 
 app.registerExtension({
     name: "VideoHelperSuite.Core",
@@ -1615,10 +1626,15 @@ app.registerExtension({
             }
         }
         api.addEventListener('VHS_latentpreview', ({detail}) => {
+            let setting = app.ui.settings.getSettingValue("VHS.LatentPreview", 'Disabled')
+            if (setting == 'Disabled') {
+                return
+            }
+            let repeat = setting == 'Continuous'
             let node = app.graph.getNodeById(detail)
             let previewWidget = node.widgets.find((w) => w.name == 'videopreview') ??
                 _addVideoPreview(node)
-            previewWidget.videoEl.src = api.apiURL('/vhs/latentvideopreview?node_id=' + detail)
+            previewWidget.videoEl.src = api.apiURL('/vhs/latentvideopreview?repeat_stale=' + repeat + '&node_id=' + detail)
             previewWidget.videoEl.autoplay = true
         });
     },

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1703,12 +1703,12 @@ api.addEventListener('VHS_latentpreview', ({ detail }) => {
         let canvasEl = previewWidget.element
         if (!ctx) {
             previewWidget.aspectRatio = previewImages[displayIndex].width / previewImages[displayIndex].height
-            canvasEl.width = previewNode.size[0]
-            canvasEl.height = previewNode.size[0] / previewWidget.aspectRatio
+            canvasEl.width = previewImages[displayIndex].width
+            canvasEl.height = previewImages[displayIndex].height
             ctx = canvasEl.getContext("2d")
             fitHeight(previewNode)
         }
-        ctx.drawImage(previewImages[displayIndex],0,0, canvasEl.width, canvasEl.height)
+        ctx.drawImage(previewImages[displayIndex],0,0)
         displayIndex = (displayIndex + 1) % previewImages.length
     }, 1000/app.ui.settings.getSettingValue("VHS.LatentPreviewRate", 8));
 });

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1336,17 +1336,17 @@ app.ui.settings.addSetting({
 });
 app.ui.settings.addSetting({
     id: "VHS.LatentPreviewRate",
-    name: "🎥🅥🅗🅢 Playback keyframe rate.",
+    name: "🎥🅥🅗🅢 Playback rate override.",
     type: "boolean",
       type: 'number',
       attrs: {
-        min: 1,
+        min: 0,
         step: 1,
         max: 60
       },
       tooltip:
-        'When dragging and resizing nodes while holding shift they will be aligned to the grid, this controls the size of that grid.',
-    defaultValue: 8,
+        'Force a specific frame rate for the playback of latent frames. This should not be confused with the outptu frame rate and will not match for video models.',
+    defaultValue: 0,
 });
 
 app.registerExtension({
@@ -1629,7 +1629,7 @@ app.registerExtension({
                 }
             }
             res.workflow.extra['VHS_latentpreview'] = app.ui.settings.getSettingValue("VHS.LatentPreview", false)
-            res.workflow.extra['VHS_latentpreviewrate'] = app.ui.settings.getSettingValue("VHS.LatentPreviewRate", 8)
+            res.workflow.extra['VHS_latentpreviewrate'] = app.ui.settings.getSettingValue("VHS.LatentPreviewRate", 0)
             return res
         }
         app.graphToPrompt = graphToPrompt
@@ -1686,7 +1686,7 @@ api.addEventListener('VHS_latentpreview', ({ detail }) => {
     let firstPreview = true
     let ctx
     previewImages = []
-    previewImages.length = detail
+    previewImages.length = detail.length
     let displayIndex = 0
     if (animateInterval) {
         clearTimeout(animateInterval)
@@ -1710,7 +1710,7 @@ api.addEventListener('VHS_latentpreview', ({ detail }) => {
         }
         ctx.drawImage(previewImages[displayIndex],0,0)
         displayIndex = (displayIndex + 1) % previewImages.length
-    }, 1000/app.ui.settings.getSettingValue("VHS.LatentPreviewRate", 8));
+    }, 1000/detail.rate);
 });
 api.addEventListener('b_preview', async (e) => {
     if (!animateInterval) {


### PR DESCRIPTION
Adds support for displaying animated video previews in KSampler nodes. I'm currently seeing negligable performance cost for latent2rgb and about 15% longer generation time for taesd. ~~Temporal VAE like mochi/ltxv have not been implemented yet.~~

Still needs quite a bit of polish ~~and to be made opt in through a setting~~, but it's functional.

https://github.com/user-attachments/assets/1f45cdbf-f7a7-48d9-b499-cc9628e4e509


https://github.com/user-attachments/assets/0f9d314e-47a0-49a3-8cbd-8c2d412eb0b1
