### PR TITLE
Add support for copying the output filepath

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -567,7 +567,8 @@ class VideoCombine:
                 "type": "output" if save_output else "temp",
                 "format": format,
                 "frame_rate": frame_rate,
-                "workflow": first_image_file
+                "workflow": first_image_file,
+                "fullpath": output_files[-1],
             }
         if num_frames == 1 and 'png' in format and '%03d' in file:
             previews[0]['format'] = 'image/png'


### PR DESCRIPTION
On right click, Video Combine nodes now have an option to copy the output filepath. Additionally, if a paste operation is performed afterwards, a Load Video (Path) node is automatically created populated with the copied file path.

From my testing, it's not possible to store an indicator to the clipboard (even with web types) to convey in the clipboard that this data was created by a VHS node, so unfortunately, this node creation capability will not persist across reloads.