### PR TITLE
Add support for trimming video to audio length

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-videohelpersuite"
 description = "Nodes related to video workflows"
-version = "1.4.1"
+version = "1.4.2"
 license = { file = "LICENSE" }
 dependencies = ["opencv-python", "imageio-ffmpeg"]
 

--- a/video_formats/h264-mp4.json
+++ b/video_formats/h264-mp4.json
@@ -9,5 +9,6 @@
     ],
     "audio_pass": ["-c:a", "aac"],
     "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],
+    "trim_to_audio": ["trim_to_audio", "BOOLEAN", {"default": false}],
     "extension": "mp4"
 }

--- a/video_formats/webm.json
+++ b/video_formats/webm.json
@@ -10,5 +10,6 @@
     ],
     "audio_pass": ["-c:a", "libvorbis"],
     "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],
+    "trim_to_audio": ["trim_to_audio", "BOOLEAN", {"default": false}],
     "extension": "webm"
 }

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -538,7 +538,7 @@ class VideoCombine:
                 #Reconsider forcing apad/shortest
                 channels = audio['waveform'].size(1)
                 min_audio_dur = total_frames_output / frame_rate + 1
-                if video_format.get('trim_to_audio', False):
+                if video_format.get('trim_to_audio', 'False') != 'False':
                     apad = []
                 else:
                     apad = ["-af", "apad=whole_dur="+str(min_audio_dur)]

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -538,12 +538,15 @@ class VideoCombine:
                 #Reconsider forcing apad/shortest
                 channels = audio['waveform'].size(1)
                 min_audio_dur = total_frames_output / frame_rate + 1
+                if video_format.get('trim_to_audio', False):
+                    apad = []
+                else:
+                    apad = ["-af", "apad=whole_dur="+str(min_audio_dur)]
                 mux_args = [ffmpeg_path, "-v", "error", "-n", "-i", file_path,
                             "-ar", str(audio['sample_rate']), "-ac", str(channels),
                             "-f", "f32le", "-i", "-", "-c:v", "copy"] \
                             + video_format["audio_pass"] \
-                            + ["-af", "apad=whole_dur="+str(min_audio_dur),
-                               "-shortest", output_file_with_audio_path]
+                            + apad + ["-shortest", output_file_with_audio_path]
 
                 audio_data = audio['waveform'].squeeze(0).transpose(0,1) \
                         .numpy().tobytes()

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1070,7 +1070,7 @@ function addFormatWidgets(nodeType) {
                             w.options.values = w.type;
                             w.type = "combo";
                         }
-                        if(inputData[1]?.default) {
+                        if(inputData[1]?.default != undefined) {
                             w.value = inputData[1].default;
                         }
                         if (w.type == "INT") {


### PR DESCRIPTION
mmaudio will frequently produce audio that is shorter than the number of input frames. Under the existing system, this results in an awkward silence at the end of videos. This adds support for a format option, trim_to_audio, which, if true, will cause these excess video frames to instead be discarded.