### PR TITLE
Add rate information for Cosmos previews

### DIFF
--- a/videohelpersuite/latent_preview.py
+++ b/videohelpersuite/latent_preview.py
@@ -11,7 +11,8 @@ serv = server.PromptServer.instance
 
 from .utils import hook
 
-rates_table = {'Mochi': 24//6, 'LTXV': 24//8, 'HunyuanVideo': 24//4}
+rates_table = {'Mochi': 24//6, 'LTXV': 24//8, 'HunyuanVideo': 24//4,
+               'Cosmos1CV8x8x8': 24//8}
 
 class WrappedPreviewer(latent_preview.LatentPreviewer):
     def __init__(self, previewer, rate=8):


### PR DESCRIPTION
At the time of this commit, latent factors have not been released for cosmos yet. Previews will not function until they are.