### PR TITLE
Merge annotated widgets, Load Formats, Preview improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-videohelpersuite"
 description = "Nodes related to video workflows"
-version = "1.4.6"
+version = "1.5.0"
 license = { file = "LICENSE" }
 dependencies = ["opencv-python", "imageio-ffmpeg"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-videohelpersuite"
 description = "Nodes related to video workflows"
-version = "1.4.5"
+version = "1.4.6"
 license = { file = "LICENSE" }
 dependencies = ["opencv-python", "imageio-ffmpeg"]
 

--- a/videohelpersuite/documentation.py
+++ b/videohelpersuite/documentation.py
@@ -123,11 +123,13 @@ descriptions = {
      'Widgets': {
          'video': 'The video file to be loaded. Lists all files with a video extension in the ComfyUI/Input folder',
          'force_rate': 'Drops or duplicates frames so that the produced output has the target frame rate. Many motion models are trained on videos of a specific frame rate and will give better results if input matches that frame rate. If set to 0, all frames are returned. May give unusual results with inputs that have a variable frame rate like animated gifs. Reducing this value can also greatly reduce the execution time and memory requirements.',
-         'force_size': ['Allows for conveniently scaling the input without requiring an additional node. Provides options to maintain aspect ratio or conveniently target common training formats for Animate Diff', {'custom_width': 'Allows for an arbitrary width to be entered, cropping to maintain aspect ratio if both are set',
-               'custom_height': 'Allows for an arbitrary height to be entered, cropping to maintain aspect ratio if both are set'}],
+         'force_size': 'Previously was used to provide suggested resolutions. Instead, custom_width and custom_height can be disabled by setting to 0.',
+         'custom_width': 'Allows for an arbitrary width to be entered, cropping to maintain aspect ratio if both are set',
+         'custom_height': 'Allows for an arbitrary height to be entered, cropping to maintain aspect ratio if both are set',
          'frame_load_cap': 'The maximum number of frames to load. If 0, all frames are loaded.',
          'skip_first_frames': 'A number of frames which are discarded before producing output.',
          'select_every_nth': 'Similar to frame rate. Keeps only the first of every n frames and discard the rest. Has better compatibility with variable frame rate inputs such as gifs. When combined with force_rate, select_every_nth_applies after force_rate so the resulting output has a frame rate equivalent to force_rate/select_every_nth. select_every_nth does not apply to skip_first_frames',
+         'format': 'Updates other widgets so that only values supported by the given format can be entered and provides recommended defaults.',
          'choose video to upload': 'An upload button is provided to upload local files to the input folder',
          'videopreview': 'Displays a preview for the selected video input. If advanced previews is enabled, this preview will reflect the frame_load_cap, force_rate, skip_first_frames, and select_every_nth values chosen. If the video has audio, it will also be previewed when moused over. Additional preview options can be accessed with right click.',
          }
@@ -150,10 +152,12 @@ descriptions = {
      'Widgets': {
          'video': 'The video file to be loaded. Lists all files with a video extension in the ComfyUI/Input folder',
          'force_rate': 'Drops or duplicates frames so that the produced output has the target frame rate. Many motion models are trained on videos of a specific frame rate and will give better results if input matches that frame rate. If set to 0, all frames are returned. May give unusual results with inputs that have a variable frame rate like animated gifs. Reducing this value can also greatly reduce the execution time and memory requirements.',
-         'force_size': ['Allows for conveniently scaling the input without requiring an additional node. Provides options to maintain aspect ratio or conveniently target common training formats for Animate Diff', {'custom_width': 'Allows for an arbitrary width to be entered, cropping to maintain aspect ratio if both are set',
-               'custom_height': 'Allows for an arbitrary height to be entered, cropping to maintain aspect ratio if both are set'}],
+         'force_size': 'Previously was used to provide suggested resolutions. Instead, custom_width and custom_height can be disabled by setting to 0.',
+         'custom_width': 'Allows for an arbitrary width to be entered, cropping to maintain aspect ratio if both are set',
+         'custom_height': 'Allows for an arbitrary height to be entered, cropping to maintain aspect ratio if both are set',
          'frame_load_cap': 'The maximum number of frames to load. If 0, all frames are loaded.',
          'start_time': 'A timestamp, in seconds from the start of the video, to start loading frames from. ',
+         'format': 'Updates other widgets so that only values supported by the given format can be entered and provides recommended defaults.',
          'choose video to upload': 'An upload button is provided to upload local files to the input folder',
          'videopreview': 'Displays a preview for the selected video input. If advanced previews is enabled, this preview will reflect the frame_load_cap, force_rate, skip_first_frames, and select_every_nth values chosen. If the video has audio, it will also be previewed when moused over. Additional preview options can be accessed with right click.',
          }
@@ -175,11 +179,13 @@ descriptions = {
      'Widgets': {
          'video': ['The video file to be loaded.', 'You can also select an image to load it as a single frame'] + common_descriptions['VHS_PATH'],
          'force_rate': 'Drops or duplicates frames so that the produced output has the target frame rate. Many motion models are trained on videos of a specific frame rate and will give better results if input matches that frame rate. If set to 0, all frames are returned. May give unusual results with inputs that have a variable frame rate like animated gifs. Reducing this value can also greatly reduce the execution time and memory requirements.',
-         'force_size': ['Allows for conveniently scaling the input without requiring an additional node. Provides options to maintain aspect ratio or conveniently target common training formats for Animate Diff', {'custom_width': 'Allows for an arbitrary width to be entered, cropping to maintain aspect ratio if both are set',
-               'custom_height': 'Allows for an arbitrary height to be entered, cropping to maintain aspect ratio if both are set'}],
+         'force_size': 'Previously was used to provide suggested resolutions. Instead, custom_width and custom_height can be disabled by setting to 0.',
+         'custom_width': 'Allows for an arbitrary width to be entered, cropping to maintain aspect ratio if both are set',
+         'custom_height': 'Allows for an arbitrary height to be entered, cropping to maintain aspect ratio if both are set',
          'frame_load_cap': 'The maximum number of frames to load. If 0, all frames are loaded.',
          'skip_first_frames': 'A number of frames which are discarded before producing output.',
          'select_every_nth': 'Similar to frame rate. Keeps only the first of every n frames and discard the rest. Has better compatibility with variable frame rate inputs such as gifs. When combined with force_rate, select_every_nth_applies after force_rate so the resulting output has a frame rate equivalent to force_rate/select_every_nth. select_every_nth does not apply to skip_first_frames',
+         'format': 'Updates other widgets so that only values supported by the given format can be entered and provides recommended defaults.',
          'videopreview': 'Displays a preview for the selected video input. Will only be shown if Advanced Previews is enabled. This preview will reflect the frame_load_cap, force_rate, skip_first_frames, and select_every_nth values chosen. If the video has audio, it will also be previewed when moused over. Additional preview options can be accessed with right click.',
          }
         }],
@@ -201,11 +207,13 @@ descriptions = {
      'Widgets': {
          'video': ['The video file to be loaded.', 'You can also select an image to load it as a single frame'] + common_descriptions['VHS_PATH'],
          'force_rate': 'Drops or duplicates frames so that the produced output has the target frame rate. Many motion models are trained on videos of a specific frame rate and will give better results if input matches that frame rate. If set to 0, all frames are returned. May give unusual results with inputs that have a variable frame rate like animated gifs. Reducing this value can also greatly reduce the execution time and memory requirements.',
-         'force_size': ['Allows for conveniently scaling the input without requiring an additional node. Provides options to maintain aspect ratio or conveniently target common training formats for Animate Diff', {'custom_width': 'Allows for an arbitrary width to be entered, cropping to maintain aspect ratio if both are set',
-               'custom_height': 'Allows for an arbitrary height to be entered, cropping to maintain aspect ratio if both are set'}],
+         'force_size': 'Previously was used to provide suggested resolutions. Instead, custom_width and custom_height can be disabled by setting to 0.',
+         'custom_width': 'Allows for an arbitrary width to be entered, cropping to maintain aspect ratio if both are set',
+         'custom_height': 'Allows for an arbitrary height to be entered, cropping to maintain aspect ratio if both are set',
          'frame_load_cap': 'The maximum number of frames to load. If 0, all frames are loaded.',
          'skip_first_frames': 'A number of frames which are discarded before producing output.',
          'select_every_nth': 'Similar to frame rate. Keeps only the first of every n frames and discard the rest. Has better compatibility with variable frame rate inputs such as gifs. When combined with force_rate, select_every_nth_applies after force_rate so the resulting output has a frame rate equivalent to force_rate/select_every_nth. select_every_nth does not apply to skip_first_frames',
+         'format': 'Updates other widgets so that only values supported by the given format can be entered and provides recommended defaults.',
          'videopreview': 'Displays a preview for the selected video input. Will only be shown if Advanced Previews is enabled. This preview will reflect the frame_load_cap, force_rate, skip_first_frames, and select_every_nth values chosen. If the video has audio, it will also be previewed when moused over. Additional preview options can be accessed with right click.',
          }
         }],

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -23,11 +23,11 @@ video_extensions = ['webm', 'mp4', 'mkv', 'gif', 'mov']
 
 VHSLoadFormats = {
     'None': {},
-    'AnimateDiff': {'target_rate': 8, 'dim': (8,0)},
-    'Mochi': {'target_rate': 24, 'dim': (8,0), 'frames':(6,1)},
-    'LTXV': {'target_rate': 24, 'dim': (8,0), 'frames':(8,1)},
-    'Hunyuan': {'target_rate': 24, 'dim': (8,0), 'frames':(4,1)},
-    'Cosmos': {'target_rate': 24, 'dim': (8,0), 'frames':(8,1)},
+    'AnimateDiff': {'target_rate': 8, 'dim': (8,0,512,512)},
+    'Mochi': {'target_rate': 24, 'dim': (8,0,848,480), 'frames':(6,1)},
+    'LTXV': {'target_rate': 24, 'dim': (8,0,768,512), 'frames':(8,1)},
+    'Hunyuan': {'target_rate': 24, 'dim': (8,0,848,480), 'frames':(4,1)},
+    'Cosmos': {'target_rate': 24, 'dim': (8,0,1280,704), 'frames':(8,1)},
 }
 """
 External plugins may add additional formats to utils.extra_config.VHSLoadFormats
@@ -298,6 +298,9 @@ def resized_cv_frame_gen(custom_width, custom_height, downscale_ratio, **kwargs)
 
 def load_video(meta_batch=None, unique_id=None, memory_limit_mb=None, vae=None,
                generator=resized_cv_frame_gen, format='None',  **kwargs):
+    if 'force_size' in kwargs:
+        kwargs.pop('force_size')
+        logger.warn("force_size has been removed. Did you reload the webpage after updating?")
     kwargs['video'] = strip_path(kwargs['video'])
     downscale_ratio = getattr(vae, "downscale_ratio", 8) if vae is not None else None
     if meta_batch is None or unique_id not in meta_batch.inputs:
@@ -417,6 +420,7 @@ class LoadVideoUpload:
                      "format": get_load_formats(),
                 },
                 "hidden": {
+                    "force_size": "STRING",
                     "unique_id": "UNIQUE_ID"
                 },
                 }
@@ -463,6 +467,7 @@ class LoadVideoPath:
                 "format": get_load_formats(),
             },
             "hidden": {
+                "force_size": "STRING",
                 "unique_id": "UNIQUE_ID"
             },
         }
@@ -513,7 +518,9 @@ class LoadVideoFFmpegUpload:
                      "format": get_load_formats(),
                 },
                 "hidden": {
+                    "force_size": "STRING",
                     "unique_id": "UNIQUE_ID"
+
                 },
                 }
 
@@ -562,6 +569,7 @@ class LoadVideoFFmpegPath:
                 "format": get_load_formats(),
             },
             "hidden": {
+                "force_size": "STRING",
                 "unique_id": "UNIQUE_ID"
             },
         }
@@ -603,6 +611,9 @@ class LoadImagePath:
             },
             "optional": {
                 "vae": ("VAE",),
+            },
+            "hidden": {
+                "force_size": "STRING",
             },
         }
 

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -305,8 +305,12 @@ def load_video(meta_batch=None, unique_id=None, memory_limit_mb=None, vae=None,
     if 'force_size' in kwargs:
         kwargs.pop('force_size')
         logger.warn("force_size has been removed. Did you reload the webpage after updating?")
+    format = get_format(format)
     kwargs['video'] = strip_path(kwargs['video'])
-    downscale_ratio = getattr(vae, "downscale_ratio", 8) if vae is not None else None
+    if vae is not None:
+        downscale_ratio = getattr(vae, "downscale_ratio", 8)
+    else:
+        downscale_ratio = format.get('dim', (1,))[0]
     if meta_batch is None or unique_id not in meta_batch.inputs:
         gen = generator(meta_batch=meta_batch, unique_id=unique_id, downscale_ratio=downscale_ratio, **kwargs)
         (width, height, fps, duration, total_frames, target_frame_time, yieldable_frames, new_width, new_height, alpha) = next(gen)
@@ -364,7 +368,6 @@ def load_video(meta_batch=None, unique_id=None, memory_limit_mb=None, vae=None,
             pass
     if len(images) == 0:
         raise RuntimeError("No frames generated")
-    format = get_format(format)
     if 'frames' in format and len(images) % format['frames'][0] != format['frames'][1]:
         err_msg = f"The number of frames loaded {len(images)}, does not match the requirements of the currently selected format."
         if len(format['frames']) > 2 and format['frames'][2]:

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -516,7 +516,7 @@ class LoadVideoFFmpegUpload:
                     "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                     "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                     "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1, "disable": 0}),
-                    "start_time": ("FLOAT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
+                    "start_time": ("FLOAT", {"default": 0, "min": 0, "max": BIGMAX, "step": .001}),
                     },
                 "optional": {
                     "meta_batch": ("VHS_BatchManager",),
@@ -567,7 +567,7 @@ class LoadVideoFFmpegPath:
                 "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                 "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                 "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1, "disable": 0}),
-                "start_time": ("FLOAT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
+                "start_time": ("FLOAT", {"default": 0, "min": 0, "max": BIGMAX, "step": .001}),
             },
             "optional": {
                 "meta_batch": ("VHS_BatchManager",),
@@ -594,6 +594,8 @@ class LoadVideoFFmpegPath:
         if is_url(kwargs['video']):
             kwargs['video'] = try_download_video(kwargs['video']) or kwargs['video']
         image, _, audio, video_info =  load_video(**kwargs, generator=ffmpeg_frame_generator)
+        if isinstance(image, dict):
+            return (image, None, audio, video_info)
         if image.size(3) == 4:
             return (image[:,:,:,:3], 1-image[:,:,:,3], audio, video_info)
         return (image, torch.zeros(image.size(0), 64, 64, device="cpu"), audio, video_info)
@@ -638,6 +640,8 @@ class LoadImagePath:
                       'start_time': 0})
         kwargs.pop('image')
         image, _, _, _ =  load_video(**kwargs, generator=ffmpeg_frame_generator)
+        if isinstance(image, dict):
+            return (image, None)
         if image.size(3) == 4:
             return (image[:,:,:,:3], 1-image[:,:,:,3])
         return (image, torch.zeros(image.size(0), 64, 64, device="cpu"))

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -16,7 +16,7 @@ from comfy.k_diffusion.utils import FolderOfImages
 from .logger import logger
 from .utils import BIGMAX, DIMMAX, calculate_file_hash, get_sorted_dir_files_from_directory,\
         lazy_get_audio, hash_path, validate_path, strip_path, try_download_video,  \
-        is_url, imageOrLatent, ffmpeg_path, ENCODE_ARGS
+        is_url, imageOrLatent, ffmpeg_path, ENCODE_ARGS, floatOrInt
 
 
 video_extensions = ['webm', 'mp4', 'mkv', 'gif', 'mov']
@@ -389,7 +389,7 @@ class LoadVideoUpload:
                     files.append(f)
         return {"required": {
                     "video": (sorted(files),),
-                    "force_rate": ("FLOAT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
+                    "force_rate": (floatOrInt, {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
                     "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                     "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                     "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1, "disable": 0}),
@@ -435,7 +435,7 @@ class LoadVideoPath:
         return {
             "required": {
                 "video": ("STRING", {"placeholder": "X://insert/path/here.mp4", "vhs_path_extensions": video_extensions}),
-                "force_rate": ("FLOAT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
+                "force_rate": (floatOrInt, {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
                 "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                 "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                 "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
@@ -486,7 +486,7 @@ class LoadVideoFFmpegUpload:
                     files.append(f)
         return {"required": {
                     "video": (sorted(files),),
-                    "force_rate": ("FLOAT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
+                    "force_rate": (floatOrInt, {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
                     "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                     "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                     "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
@@ -535,7 +535,7 @@ class LoadVideoFFmpegPath:
         return {
             "required": {
                 "video": ("STRING", {"placeholder": "X://insert/path/here.mp4", "vhs_path_extensions": video_extensions}),
-                "force_rate": ("FLOAT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
+                "force_rate": (floatOrInt, {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
                 "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                 "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                 "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -45,6 +45,10 @@ def get_load_formats():
     formats.update(VHSLoadFormats)
     return (list(formats.keys()),
             {'default': 'AnimateDiff', 'formats': formats})
+def get_format(format):
+    if format in VHSLoadFormats:
+        return VHSLoadFormats[format]
+    return nodes.VHSLoadFormats.get(format, {})
 
 def is_gif(filename) -> bool:
     file_parts = filename.split('.')
@@ -360,14 +364,16 @@ def load_video(meta_batch=None, unique_id=None, memory_limit_mb=None, vae=None,
             pass
     if len(images) == 0:
         raise RuntimeError("No frames generated")
+    format = get_format(format)
     if 'frames' in format and len(images) % format['frames'][0] != format['frames'][1]:
         err_msg = f"The number of frames loaded {len(images)}, does not match the requirements of the currently selected format."
         if len(format['frames']) > 2 and format['frames'][2]:
             raise RuntimeError(err_msg)
-        div, mod = format['frames']
-        frames = (len(images) - mod) // div + mod
+        div, mod = format['frames'][:2]
+        frames = (len(images) - mod) // div * div + mod
         images = images[:frames]
-        logger.warn(err_msg + f" Output has been truncated to {len(images)} frames.")
+        #Commenting out log message since it's displayed in UI. consider further
+        #logger.warn(err_msg + f" Output has been truncated to {len(images)} frames.")
     if 'start_time' in kwargs:
         start_time = kwargs['start_time']
     else:

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -23,19 +23,23 @@ video_extensions = ['webm', 'mp4', 'mkv', 'gif', 'mov']
 
 if not hasattr(extra_config, 'VHSLoadFormats'):
     extra_config.VHSLoadFormats = {}
-extra_config.VHSLoadFormats.update({
+VHSLoadFormats = {
     'None': {},
     'AnimateDiff': {'target_rate': 8, 'dim': (8,0)},
     'Mochi': {'target_rate': 24, 'dim': (8,0), 'frames':(6,1)},
     'LTXV': {'target_rate': 24, 'dim': (8,0), 'frames':(8,1)},
     'Hunyuan': {'target_rate': 24, 'dim': (8,0), 'frames':(4,1)},
     'Cosmos': {'target_rate': 24, 'dim': (8,0), 'frames':(8,1)},
-})
+}
 def get_load_formats():
     return (list(extra_config.VHSLoadFormats.keys()),
             {'default': 'AnimateDiff', 'formats': extra_config.VHSLoadFormats})
 
 def is_gif(filename) -> bool:
+    #TODO: check if {**extra_config.VHSLoafFormats, **VHSLoadFormats} has minimum version
+    formats = {}
+    formats.update(extra_config.VHSLoadFormats)
+    formats.update(VHSLoadFormats)
     file_parts = filename.split('.')
     return len(file_parts) > 1 and file_parts[-1] == "gif"
 
@@ -386,9 +390,9 @@ class LoadVideoUpload:
         return {"required": {
                     "video": (sorted(files),),
                     "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
-                    "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
-                    "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
-                    "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
+                    "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
+                    "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
+                    "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1, "disable": 0}),
                     "skip_first_frames": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                     "select_every_nth": ("INT", {"default": 1, "min": 1, "max": BIGMAX, "step": 1}),
                     },
@@ -432,8 +436,8 @@ class LoadVideoPath:
             "required": {
                 "video": ("STRING", {"placeholder": "X://insert/path/here.mp4", "vhs_path_extensions": video_extensions}),
                 "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
-                "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
-                "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
+                "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
+                "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                 "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                 "skip_first_frames": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                 "select_every_nth": ("INT", {"default": 1, "min": 1, "max": BIGMAX, "step": 1}),
@@ -483,8 +487,8 @@ class LoadVideoFFmpegUpload:
         return {"required": {
                     "video": (sorted(files),),
                     "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
-                    "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
-                    "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
+                    "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
+                    "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                     "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                     "start_time": ("FLOAT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                     },
@@ -532,8 +536,8 @@ class LoadVideoFFmpegPath:
             "required": {
                 "video": ("STRING", {"placeholder": "X://insert/path/here.mp4", "vhs_path_extensions": video_extensions}),
                 "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
-                "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
-                "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
+                "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
+                "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                 "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                 "start_time": ("FLOAT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
             },

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -11,6 +11,7 @@ import time
 
 import folder_paths
 from comfy.utils import common_upscale, ProgressBar
+from utils import extra_config
 from comfy.k_diffusion.utils import FolderOfImages
 from .logger import logger
 from .utils import BIGMAX, DIMMAX, calculate_file_hash, get_sorted_dir_files_from_directory,\
@@ -20,21 +21,34 @@ from .utils import BIGMAX, DIMMAX, calculate_file_hash, get_sorted_dir_files_fro
 
 video_extensions = ['webm', 'mp4', 'mkv', 'gif', 'mov']
 
+if not hasattr(extra_config, 'VHSLoadFormats'):
+    extra_config.VHSLoadFormats = {}
+extra_config.VHSLoadFormats.update({
+    'None': {},
+    'AnimateDiff': {'target_rate': 8, 'dim': (8,0)},
+    'Mochi': {'target_rate': 24, 'dim': (8,0), 'frames':(6,1)},
+    'LTXV': {'target_rate': 24, 'dim': (8,0), 'frames':(8,1)},
+    'Hunyuan': {'target_rate': 24, 'dim': (8,0), 'frames':(4,1)},
+    'Cosmos': {'target_rate': 24, 'dim': (8,0), 'frames':(8,1)},
+})
+def get_load_formats():
+    return (list(extra_config.VHSLoadFormats.keys()),
+            {'default': 'AnimateDiff', 'formats': extra_config.VHSLoadFormats})
 
 def is_gif(filename) -> bool:
     file_parts = filename.split('.')
     return len(file_parts) > 1 and file_parts[-1] == "gif"
 
 
-def target_size(width, height, force_size, custom_width, custom_height, downscale_ratio=8) -> tuple[int, int]:
+def target_size(width, height, custom_width, custom_height, downscale_ratio=8) -> tuple[int, int]:
     if downscale_ratio is None:
         downscale_ratio = 8
-    if force_size == "Disabled":
+    if custom_width == 0 and custom_height ==  0:
         pass
-    elif force_size == "Custom Width" or force_size.endswith('x?'):
+    elif custom_height == 0:
         height *= custom_width/width
         width = custom_width
-    elif force_size == "Custom Height" or force_size.startswith('?x'):
+    elif custom_width == 0:
         width *= custom_height/height
         height = custom_height
     else:
@@ -138,7 +152,7 @@ def cv_frame_generator(video, force_rate, frame_load_cap, skip_first_frames,
         yield prev_frame
 
 def ffmpeg_frame_generator(video, force_rate, frame_load_cap, start_time,
-                           force_size, custom_width, custom_height, downscale_ratio=8,
+                           custom_width, custom_height, downscale_ratio=8,
                            meta_batch=None, unique_id=None):
     args_dummy = [ffmpeg_path, "-i", video, '-c', 'copy', '-frames:v', '1', "-f", "null", "-"]
     size_base = None
@@ -184,8 +198,8 @@ def ffmpeg_frame_generator(video, force_rate, frame_load_cap, start_time,
     vfilters = []
     if force_rate != 0:
         vfilters.append("fps=fps="+str(force_rate))
-    if force_size != "Disabled":
-        size = target_size(size_base[0], size_base[1], force_size, custom_width,
+    if custom_width != 0 or custom_height != 0:
+        size = target_size(size_base[0], size_base[1], custom_width,
                            custom_height, downscale_ratio=downscale_ratio)
         ar = float(size[0])/float(size[1])
         if abs(size_base[0]*ar-size_base[1]) >= 1:
@@ -245,15 +259,15 @@ def batched_vae_encode(images, vae, frames_per_batch):
     for batch in batched(images, frames_per_batch):
         image_batch = torch.from_numpy(np.array(batch))
         yield from vae.encode(image_batch).numpy()
-def resized_cv_frame_gen(custom_width, custom_height, force_size, downscale_ratio, **kwargs):
+def resized_cv_frame_gen(custom_width, custom_height, downscale_ratio, **kwargs):
     gen = cv_frame_generator(**kwargs)
     info =  next(gen)
     width, height = info[0], info[1]
     frames_per_batch = (1920 * 1080 * 16) // (width * height) or 1
     if kwargs.get('meta_batch', None) is not None:
         frames_per_batch = min(frames_per_batch, kwargs['meta_batch'].frames_per_batch)
-    if force_size != "Disabled" or downscale_ratio is not None:
-        new_size = target_size(width, height, force_size, custom_width, custom_height, downscale_ratio)
+    if custom_width != 0 or custom_height != 0 or downscale_ratio is not None:
+        new_size = target_size(width, height, custom_width, custom_height, downscale_ratio)
         yield (*info, new_size[0], new_size[1], False)
         if new_size[0] != width or new_size[1] != height:
             def rescale(frame):
@@ -268,7 +282,7 @@ def resized_cv_frame_gen(custom_width, custom_height, force_size, downscale_rati
     yield from gen
 
 def load_video(meta_batch=None, unique_id=None, memory_limit_mb=None, vae=None,
-               generator=resized_cv_frame_gen, **kwargs):
+               generator=resized_cv_frame_gen, format='None',  **kwargs):
     kwargs['video'] = strip_path(kwargs['video'])
     downscale_ratio = getattr(vae, "downscale_ratio", 8) if vae is not None else None
     if meta_batch is None or unique_id not in meta_batch.inputs:
@@ -293,21 +307,24 @@ def load_video(meta_batch=None, unique_id=None, memory_limit_mb=None, vae=None,
             memory_limit = (psutil.virtual_memory().available + psutil.swap_memory().free) - 2 ** 27
         except:
             logger.warn("Failed to calculate available memory. Memory load limit has been disabled")
-    if memory_limit is not None:
-        if vae is not None:
-            #space required to load as f32, exist as latent with wiggle room, decode to f32
-            max_loadable_frames = int(memory_limit//(width*height*3*(4+4+1/10)))
-        else:
-            #TODO: use better estimate for when vae is not None
-            #Consider completely ignoring for load_latent case?
-            max_loadable_frames = int(memory_limit//(width*height*3*(.1)))
-        if meta_batch is not None:
-            if meta_batch.frames_per_batch > max_loadable_frames:
-                raise RuntimeError(f"Meta Batch set to {meta_batch.frames_per_batch} frames but only {max_loadable_frames} can fit in memory")
-            gen = itertools.islice(gen, meta_batch.frames_per_batch)
-        else:
-            original_gen = gen
-            gen = itertools.islice(gen, max_loadable_frames)
+            memory_limit = BIGMAX
+    if vae is not None:
+        #space required to load as f32, exist as latent with wiggle room, decode to f32
+        max_loadable_frames = int(memory_limit//(width*height*3*(4+4+1/10)))
+    else:
+        #TODO: use better estimate for when vae is not None
+        #Consider completely ignoring for load_latent case?
+        max_loadable_frames = int(memory_limit//(width*height*3*(.1)))
+    if meta_batch is not None:
+        if 'frames' in format:
+            assert frames_per_batch % format['frames'][0] == format['frames'][1], \
+                   "The chosen frames per batch is incompatible with the selected format"
+        if meta_batch.frames_per_batch > max_loadable_frames:
+            raise RuntimeError(f"Meta Batch set to {meta_batch.frames_per_batch} frames but only {max_loadable_frames} can fit in memory")
+        gen = itertools.islice(gen, meta_batch.frames_per_batch)
+    else:
+        original_gen = gen
+        gen = itertools.islice(gen, max_loadable_frames)
     frames_per_batch = (1920 * 1080 * 16) // (width * height) or 1
     if vae is not None:
         gen = batched_vae_encode(gen, vae, frames_per_batch)
@@ -325,7 +342,10 @@ def load_video(meta_batch=None, unique_id=None, memory_limit_mb=None, vae=None,
             pass
     if len(images) == 0:
         raise RuntimeError("No frames generated")
-
+    if 'frames' in format and len(images) % format['frames'][0] != format['frames'][1]:
+        div, mod = format['frames']
+        frames = (len(images) - mod) // div + mod
+        images = images[:frames]
     if 'start_time' in kwargs:
         start_time = kwargs['start_time']
     else:
@@ -366,9 +386,8 @@ class LoadVideoUpload:
         return {"required": {
                     "video": (sorted(files),),
                      "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1}),
-                     "force_size": (["Disabled", "Custom Height", "Custom Width", "Custom", "256x?", "?x256", "256x256", "512x?", "?x512", "512x512"],),
-                     "custom_width": ("INT", {"default": 512, "min": 0, "max": DIMMAX, "step": 8}),
-                     "custom_height": ("INT", {"default": 512, "min": 0, "max": DIMMAX, "step": 8}),
+                     "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
+                     "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
                      "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                      "skip_first_frames": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                      "select_every_nth": ("INT", {"default": 1, "min": 1, "max": BIGMAX, "step": 1}),
@@ -376,6 +395,7 @@ class LoadVideoUpload:
                 "optional": {
                     "meta_batch": ("VHS_BatchManager",),
                     "vae": ("VAE",),
+                     "format": get_load_formats(),
                 },
                 "hidden": {
                     "unique_id": "UNIQUE_ID"
@@ -399,7 +419,7 @@ class LoadVideoUpload:
         return calculate_file_hash(image_path)
 
     @classmethod
-    def VALIDATE_INPUTS(s, video, force_size, **kwargs):
+    def VALIDATE_INPUTS(s, video, **kwargs):
         if not folder_paths.exists_annotated_filepath(video):
             return "Invalid video file: {}".format(video)
         return True
@@ -412,9 +432,8 @@ class LoadVideoPath:
             "required": {
                 "video": ("STRING", {"placeholder": "X://insert/path/here.mp4", "vhs_path_extensions": video_extensions}),
                 "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1}),
-                 "force_size": (["Disabled", "Custom Height", "Custom Width", "Custom", "256x?", "?x256", "256x256", "512x?", "?x512", "512x512"],),
-                 "custom_width": ("INT", {"default": 512, "min": 0, "max": DIMMAX, "step": 8}),
-                 "custom_height": ("INT", {"default": 512, "min": 0, "max": DIMMAX, "step": 8}),
+                "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
+                "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
                 "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                 "skip_first_frames": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                 "select_every_nth": ("INT", {"default": 1, "min": 1, "max": BIGMAX, "step": 1}),
@@ -422,6 +441,7 @@ class LoadVideoPath:
             "optional": {
                 "meta_batch": ("VHS_BatchManager",),
                 "vae": ("VAE",),
+                "format": get_load_formats(),
             },
             "hidden": {
                 "unique_id": "UNIQUE_ID"
@@ -463,15 +483,15 @@ class LoadVideoFFmpegUpload:
         return {"required": {
                     "video": (sorted(files),),
                      "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1}),
-                     "force_size": (["Disabled", "Custom Height", "Custom Width", "Custom", "256x?", "?x256", "256x256", "512x?", "?x512", "512x512"],),
-                     "custom_width": ("INT", {"default": 512, "min": 0, "max": DIMMAX, "step": 8}),
-                     "custom_height": ("INT", {"default": 512, "min": 0, "max": DIMMAX, "step": 8}),
+                     "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
+                     "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
                      "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                      "start_time": ("FLOAT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                      },
                 "optional": {
                     "meta_batch": ("VHS_BatchManager",),
                     "vae": ("VAE",),
+                     "format": get_load_formats(),
                 },
                 "hidden": {
                     "unique_id": "UNIQUE_ID"
@@ -499,7 +519,7 @@ class LoadVideoFFmpegUpload:
         return calculate_file_hash(image_path)
 
     @classmethod
-    def VALIDATE_INPUTS(s, video, force_size, **kwargs):
+    def VALIDATE_INPUTS(s, video, **kwargs):
         if not folder_paths.exists_annotated_filepath(video):
             return "Invalid video file: {}".format(video)
         return True
@@ -512,15 +532,15 @@ class LoadVideoFFmpegPath:
             "required": {
                 "video": ("STRING", {"placeholder": "X://insert/path/here.mp4", "vhs_path_extensions": video_extensions}),
                 "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1}),
-                 "force_size": (["Disabled", "Custom Height", "Custom Width", "Custom", "256x?", "?x256", "256x256", "512x?", "?x512", "512x512"],),
-                 "custom_width": ("INT", {"default": 512, "min": 0, "max": DIMMAX, "step": 8}),
-                 "custom_height": ("INT", {"default": 512, "min": 0, "max": DIMMAX, "step": 8}),
+                "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
+                "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
                 "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                 "start_time": ("FLOAT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
             },
             "optional": {
                 "meta_batch": ("VHS_BatchManager",),
                 "vae": ("VAE",),
+                "format": get_load_formats(),
             },
             "hidden": {
                 "unique_id": "UNIQUE_ID"
@@ -559,9 +579,8 @@ class LoadImagePath:
         return {
             "required": {
                 "image": ("STRING", {"placeholder": "X://insert/path/here.png", "vhs_path_extensions": list(FolderOfImages.IMG_EXTENSIONS)}),
-                 "force_size": (["Disabled", "Custom Height", "Custom Width", "Custom", "256x?", "?x256", "256x256", "512x?", "?x512", "512x512"],),
-                 "custom_width": ("INT", {"default": 512, "min": 0, "max": DIMMAX, "step": 8}),
-                 "custom_height": ("INT", {"default": 512, "min": 0, "max": DIMMAX, "step": 8}),
+                "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
+                "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
             },
             "optional": {
                 "vae": ("VAE",),

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -385,13 +385,13 @@ class LoadVideoUpload:
                     files.append(f)
         return {"required": {
                     "video": (sorted(files),),
-                     "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1}),
-                     "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
-                     "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
-                     "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
-                     "skip_first_frames": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
-                     "select_every_nth": ("INT", {"default": 1, "min": 1, "max": BIGMAX, "step": 1}),
-                     },
+                    "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
+                    "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
+                    "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
+                    "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
+                    "skip_first_frames": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
+                    "select_every_nth": ("INT", {"default": 1, "min": 1, "max": BIGMAX, "step": 1}),
+                    },
                 "optional": {
                     "meta_batch": ("VHS_BatchManager",),
                     "vae": ("VAE",),
@@ -431,7 +431,7 @@ class LoadVideoPath:
         return {
             "required": {
                 "video": ("STRING", {"placeholder": "X://insert/path/here.mp4", "vhs_path_extensions": video_extensions}),
-                "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1}),
+                "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
                 "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
                 "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
                 "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
@@ -482,12 +482,12 @@ class LoadVideoFFmpegUpload:
                     files.append(f)
         return {"required": {
                     "video": (sorted(files),),
-                     "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1}),
-                     "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
-                     "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
-                     "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
-                     "start_time": ("FLOAT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
-                     },
+                    "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
+                    "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
+                    "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
+                    "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
+                    "start_time": ("FLOAT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
+                    },
                 "optional": {
                     "meta_batch": ("VHS_BatchManager",),
                     "vae": ("VAE",),
@@ -531,7 +531,7 @@ class LoadVideoFFmpegPath:
         return {
             "required": {
                 "video": ("STRING", {"placeholder": "X://insert/path/here.mp4", "vhs_path_extensions": video_extensions}),
-                "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1}),
+                "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
                 "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
                 "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, "step": 8, 'disable': 0}),
                 "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -32,14 +32,14 @@ VHSLoadFormats = {
     'Cosmos': {'target_rate': 24, 'dim': (8,0), 'frames':(8,1)},
 }
 def get_load_formats():
-    return (list(extra_config.VHSLoadFormats.keys()),
-            {'default': 'AnimateDiff', 'formats': extra_config.VHSLoadFormats})
-
-def is_gif(filename) -> bool:
     #TODO: check if {**extra_config.VHSLoafFormats, **VHSLoadFormats} has minimum version
     formats = {}
     formats.update(extra_config.VHSLoadFormats)
     formats.update(VHSLoadFormats)
+    return (list(formats.keys()),
+            {'default': 'AnimateDiff', 'formats': formats})
+
+def is_gif(filename) -> bool:
     file_parts = filename.split('.')
     return len(file_parts) > 1 and file_parts[-1] == "gif"
 
@@ -438,7 +438,7 @@ class LoadVideoPath:
                 "force_rate": (floatOrInt, {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
                 "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                 "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
-                "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
+                "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1, "disable": 0}),
                 "skip_first_frames": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                 "select_every_nth": ("INT", {"default": 1, "min": 1, "max": BIGMAX, "step": 1}),
             },
@@ -489,7 +489,7 @@ class LoadVideoFFmpegUpload:
                     "force_rate": (floatOrInt, {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
                     "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                     "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
-                    "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
+                    "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1, "disable": 0}),
                     "start_time": ("FLOAT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
                     },
                 "optional": {
@@ -538,7 +538,7 @@ class LoadVideoFFmpegPath:
                 "force_rate": (floatOrInt, {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
                 "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                 "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
-                "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
+                "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1, "disable": 0}),
                 "start_time": ("FLOAT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
             },
             "optional": {

--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -389,7 +389,7 @@ class LoadVideoUpload:
                     files.append(f)
         return {"required": {
                     "video": (sorted(files),),
-                    "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
+                    "force_rate": ("FLOAT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
                     "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                     "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                     "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1, "disable": 0}),
@@ -435,7 +435,7 @@ class LoadVideoPath:
         return {
             "required": {
                 "video": ("STRING", {"placeholder": "X://insert/path/here.mp4", "vhs_path_extensions": video_extensions}),
-                "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
+                "force_rate": ("FLOAT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
                 "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                 "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                 "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
@@ -486,7 +486,7 @@ class LoadVideoFFmpegUpload:
                     files.append(f)
         return {"required": {
                     "video": (sorted(files),),
-                    "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
+                    "force_rate": ("FLOAT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
                     "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                     "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                     "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
@@ -535,7 +535,7 @@ class LoadVideoFFmpegPath:
         return {
             "required": {
                 "video": ("STRING", {"placeholder": "X://insert/path/here.mp4", "vhs_path_extensions": video_extensions}),
-                "force_rate": ("INT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
+                "force_rate": ("FLOAT", {"default": 0, "min": 0, "max": 60, "step": 1, "disable": 0}),
                 "custom_width": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                 "custom_height": ("INT", {"default": 0, "min": 0, "max": DIMMAX, 'disable': 0}),
                 "frame_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -22,7 +22,7 @@ from .load_images_nodes import LoadImagesFromDirectoryUpload, LoadImagesFromDire
 from .batched_nodes import VAEEncodeBatched, VAEDecodeBatched
 from .utils import ffmpeg_path, get_audio, hash_path, validate_path, requeue_workflow, \
         gifski_path, calculate_file_hash, strip_path, try_download_video, is_url, \
-        imageOrLatent, BIGMAX, merge_filter_args, ENCODE_ARGS
+        imageOrLatent, BIGMAX, merge_filter_args, ENCODE_ARGS, floatOrInt
 from comfy.utils import ProgressBar
 
 folder_paths.folder_names_and_paths["VHS_video_formats"] = (
@@ -204,7 +204,7 @@ class VideoCombine:
             "required": {
                 "images": (imageOrLatent,),
                 "frame_rate": (
-                    "FLOAT",
+                    floatOrInt,
                     {"default": 8, "min": 1, "step": 1},
                 ),
                 "loop_count": ("INT", {"default": 0, "min": 0, "max": 100, "step": 1}),

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -398,7 +398,7 @@ class VideoCombine:
 
             video_format = apply_format_widgets(format_ext, kwargs)
             has_alpha = first_image.shape[-1] == 4
-            dim_alignment = video_format.get("dim_alignment", 8)
+            dim_alignment = video_format.get("dim_alignment", 2)
             if (first_image.shape[1] % dim_alignment) or (first_image.shape[0] % dim_alignment):
                 #output frames must be padded
                 to_pad = (-first_image.shape[1] % dim_alignment,

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -54,6 +54,8 @@ async def view_video(request):
         else:
             if not os.path.isfile(file) and not validate_sequence(file):
                     return web.Response(status=404)
+    if query.get('skip_encode', False) or ffmpeg_path is None:
+        return web.FileResponse(path=file)
 
     frame_rate = query.get('frame_rate', 8)
     if query.get('format', 'video') == "folder":

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -175,6 +175,7 @@ async def query_video(request):
         duration = int(durs[0])*360 + int(durs[1])*60 + float(durs[2])
         results['duration'] = duration
         results['frames'] = int(duration*results['fps'])
+    results = {'source': results}
     query_cache[filepath] = (os.stat(filepath).st_mtime, results)
     return web.json_response(results)
 

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -102,8 +102,12 @@ async def view_video(request):
     if int(query.get('frame_load_cap', 0)) > 0:
         args += ["-frames:v", query['frame_load_cap']]
     #TODO:reconsider adding high frame cap/setting default frame cap on node
+    if query.get('deadline', 'realtime') == 'good':
+        deadline = 'good'
+    else:
+        deadline = 'realtime'
 
-    args += ['-c:v', 'libvpx-vp9','-deadline', 'realtime', '-cpu-used', '8', '-f', 'webm', '-']
+    args += ['-c:v', 'libvpx-vp9','-deadline', deadline, '-cpu-used', '8', '-f', 'webm', '-']
 
     try:
         with subprocess.Popen(args, stdout=subprocess.PIPE) as proc:

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -55,7 +55,9 @@ async def view_video(request):
             if not os.path.isfile(file) and not validate_sequence(file):
                     return web.Response(status=404)
     if query.get('skip_encode', False) or ffmpeg_path is None:
-        return web.FileResponse(path=file)
+        #Don't just return file, that provides  arbitrary read access to any file
+        if is_safe_path(output_dir, strict=True):
+            return web.FileResponse(path=file)
 
     frame_rate = query.get('frame_rate', 8)
     if query.get('format', 'video') == "folder":

--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -61,8 +61,6 @@ async def view_video(request):
 
     frame_rate = query.get('frame_rate', 8)
     if query.get('format', 'video') == "folder":
-        #Check that folder contains some valid image file, get it's extension
-        #ffmpeg seems to not support list globs, so support for mixed extensions seems unfeasible
         os.makedirs(folder_paths.get_temp_directory(), exist_ok=True)
         concat_file = os.path.join(folder_paths.get_temp_directory(), "image_sequence_preview.txt")
         skip_first_images = int(query.get('skip_first_images', 0))

--- a/videohelpersuite/utils.py
+++ b/videohelpersuite/utils.py
@@ -109,8 +109,8 @@ def try_download_video(url):
     download_history[url] = file
     return file
 
-def is_safe_path(path):
-    if "VHS_STRICT_PATHS" not in os.environ:
+def is_safe_path(path, strict=False):
+    if "VHS_STRICT_PATHS" not in os.environ and not strict:
         return True
     basedir = os.path.abspath('.')
     try:

--- a/videohelpersuite/utils.py
+++ b/videohelpersuite/utils.py
@@ -42,10 +42,17 @@ def ffmpeg_suitability(path):
             score += int(copyright_year)
     return score
 
-class ImageOrLatent(str):
+class MultiInput(str):
+    def __new__(cls, string, allowed_types="*"):
+        res = super().__new__(cls, string)
+        res.allowed_types=allowed_types
+        return res
     def __ne__(self, other):
-        return not (other == "IMAGE" or other == "LATENT" or other == "*")
-imageOrLatent = ImageOrLatent("IMAGE")
+        if self.allowed_types == "*" or other == "*":
+            return False
+        return other not in self.allowed_types
+imageOrLatent = MultiInput("IMAGE", ["IMAGE", "LATENT"])
+floatOrInt = MultiInput("FLOAT", ["FLOAT", "INT"])
 
 if "VHS_FORCE_FFMPEG_PATH" in os.environ:
     ffmpeg_path = os.environ.get("VHS_FORCE_FFMPEG_PATH")

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -884,23 +884,16 @@ function addVideoPreview(nodeType, isInput=true) {
                 if (target_width < minWidth) {
                     target_width = min_width
                 }
-                if (!params.force_size || params.force_size.includes("?") || params.force_size == "Disabled") {
+                if (!params.custom_width || !params.custom_height) {
                     params.force_size = target_width+"x?"
                 } else {
-                    let size = params.force_size.split("x")
-                    let ar = parseInt(size[0])/parseInt(size[1])
+                    let ar = params.custom_width/params.custom_height
                     params.force_size = target_width+"x"+(target_width/ar)
                 }
-                let encodedSource = document.createElement("source")
-                let rawSource = document.createElement("source")
-                encodedSource.type = 'video/webm'
-                encodedSource.src = api.apiURL('/vhs/viewvideo?' + new URLSearchParams(params));
-                params.skip_encode = true
-                rawSource.src = api.apiURL('/vhs/viewvideo?' + new URLSearchParams(params));
                 if (advp == 'Never' || advp == 'Input Only' && !isInput) {
-                    this.videoEl.replaceChildren(rawSource, encodedSource)
+                    this.videoEl.src = api.apiURL('/view?' + new URLSearchParams(params));
                 } else {
-                    this.videoEl.replaceChildren(encodedSource, rawSource)
+                    this.videoEl.src = api.apiURL('/vhs/viewvideo?' + new URLSearchParams(params));
                 }
                 this.videoEl.hidden = false;
                 this.imgEl.hidden = true;
@@ -1140,9 +1133,6 @@ function addFormatWidgets(nodeType) {
     });
 }
 function addLoadCommon(nodeType, nodeData) {
-    if (nodeData?.input?.required?.force_size) {
-        addCustomSize(nodeType, nodeData, "force_size")
-    }
     initializeLoadFormat(nodeType, nodeData)
     addVideoPreview(nodeType);
     addPreviewOptions(nodeType);

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -506,7 +506,8 @@ function applyVHSAudioLinksFix(nodeType, nodeData, audio_slot) {
 }
 function addVAEOutputToggle(nodeType, nodeData) {
     chainCallback(nodeType.prototype, "onConnectionsChange", function(contype, slot, iscon, linfo) {
-        if (contype == LiteGraph.INPUT && slot == 1 && this.inputs[1].type == "VAE") {
+        let slotType = this.inputs[slot]?.type
+        if (contype == LiteGraph.INPUT && slotType == "VAE") {
             if (iscon && linfo) {
                 if (this.linkTimeout) {
                     clearTimeout(this.linkTimeout)
@@ -931,9 +932,9 @@ function addVideoPreview(nodeType, isInput=true) {
                     //overscale to allow scrolling. Endpoint won't return higher than native
                     target_width = previewWidget.element.style.width.slice(0,-2)*2;
                 }
-                let minWidth = app.ui.settings.getSettingValue("VHS>AdvandedPreviewsMinWidth")
+                let minWidth = app.ui.settings.getSettingValue("VHS.AdvancedPreviewsMinWidth")
                 if (target_width < minWidth) {
-                    target_width = min_width
+                    target_width = minWidth
                 }
                 if (!params.custom_width || !params.custom_height) {
                     params.force_size = target_width+"x?"
@@ -1197,6 +1198,10 @@ function addLoadCommon(nodeType, nodeData) {
                     'custom_height': heightWidget.value})
                 prior_ar = new_ar
             }
+        }
+        const offsetWidget = this.widgets.find((w) => w.name === "start_time");
+        if (offsetWidget) {
+            offsetWidget.options.step = 10
         }
         let widgetMap = {'frame_load_cap': 'frame_load_cap',
             'skip_first_frames': 'skip_first_frames', 'select_every_nth': 'select_every_nth',

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -624,6 +624,9 @@ function addTimestampWidget(nodeType, nodeData, targetWidget) {
     });
 }
 function initializeLoadFormat(nodeType, nodeData) {
+    if (!nodeData?.input?.optional?.format) {
+        return
+    }
     chainCallback(nodeType.prototype, "onNodeCreated", function() {
         let node = this
         let formatWidget = this.widgets.find((w) => w.name === "format")
@@ -1156,7 +1159,7 @@ function addLoadCommon(nodeType, nodeData) {
             'skip_first_frames': 'skip_first_frames', 'select_every_nth': 'select_every_nth',
             'start_time': 'start_time', 'force_rate': 'force_rate',
             'custom_width': updateAR, 'custom_height': updateAR,
-            'image_load_cap': 'frame_load_cap', 'skip_first_images': 'skip_first_frames'
+            'image_load_cap': 'image_load_cap', 'skip_first_images': 'skip_first_images'
         }
         let updated = []
         for (let widget of this.widgets) {

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1750,10 +1750,6 @@ app.registerExtension({
             });
             addLoadCommon(nodeType, nodeData);
         } else if (nodeData?.name == "VHS_LoadVideo" || nodeData?.name == "VHS_LoadVideoFFmpeg") {
-            addUploadWidget(nodeType, nodeData, "video");
-            addLoadCommon(nodeType, nodeData);
-            addVAEOutputToggle(nodeType, nodeData);
-            applyVHSAudioLinksFix(nodeType, nodeData, 2)
             chainCallback(nodeType.prototype, "onNodeCreated", function() {
                 const pathWidget = this.widgets.find((w) => w.name === "video");
                 chainCallback(pathWidget, "callback", (value) => {
@@ -1772,15 +1768,16 @@ app.registerExtension({
                     this.updateParameters(params, true);
                 });
             });
+            addUploadWidget(nodeType, nodeData, "video");
+            addLoadCommon(nodeType, nodeData);
+            addVAEOutputToggle(nodeType, nodeData);
+            applyVHSAudioLinksFix(nodeType, nodeData, 2)
         } else if (nodeData?.name == "VHS_LoadAudioUpload") {
             addUploadWidget(nodeType, nodeData, "audio", "audio");
             applyVHSAudioLinksFix(nodeType, nodeData, 0)
         } else if (nodeData?.name == "VHS_LoadAudio"){
             applyVHSAudioLinksFix(nodeType, nodeData, 0)
         } else if (nodeData?.name == "VHS_LoadVideoPath" || nodeData?.name == "VHS_LoadVideoFFmpegPath") {
-            addLoadCommon(nodeType, nodeData);
-            addVAEOutputToggle(nodeType, nodeData);
-            applyVHSAudioLinksFix(nodeType, nodeData, 2)
             chainCallback(nodeType.prototype, "onNodeCreated", function() {
                 const pathWidget = this.widgets.find((w) => w.name === "video");
                 chainCallback(pathWidget, "callback", (value) => {
@@ -1795,6 +1792,9 @@ app.registerExtension({
                     this.updateParameters(params, true);
                 });
             });
+            addLoadCommon(nodeType, nodeData);
+            addVAEOutputToggle(nodeType, nodeData);
+            applyVHSAudioLinksFix(nodeType, nodeData, 2)
         } else if (nodeData?.name == "VHS_LoadImagePath") {
             addLoadCommon(nodeType, nodeData);
             addVAEOutputToggle(nodeType, nodeData);

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -147,6 +147,10 @@ function useKVState(nodeType) {
         });
     })
 }
+app.VHSLoadFormats = {
+    'AnimateDiff': {'rate': {'default': 8}, 'dim': {'default': 512, 'step': 8}},
+    'None': {}
+}
 var helpDOM;
 if (!app.helpDOM) {
     helpDOM = document.createElement("div");
@@ -1133,6 +1137,7 @@ function addLoadCommon(nodeType, nodeData) {
     if (nodeData?.input?.required?.force_size) {
         addCustomSize(nodeType, nodeData, "force_size")
     }
+    addVideoPreview(nodeType);
     addPreviewOptions(nodeType);
     chainCallback(nodeType.prototype, "onNodeCreated", function() {
         //widget.callback adds unused arguements which need culling
@@ -1344,6 +1349,209 @@ function searchBox(event, [x,y], node) {
 
     return dialog;
 }
+function button_action(widget) {
+  if (
+    widget.options?.reset == undefined &&
+    widget.options?.disable == undefined
+  ) {
+    return 'None'
+  }
+  if (
+    widget.options.reset != undefined &&
+    widget.value != widget.options.reset
+  ) {
+    return 'Reset'
+  }
+  if (
+    widget.options.disable != undefined &&
+    widget.value != widget.options.disable
+  ) {
+    return 'Disable'
+  }
+  if (widget.options.reset != undefined) {
+    return 'No Reset'
+  }
+  return 'No Disable'
+}
+function inner_value_change(widget, value, node, pos) {
+  widget.value = value
+  if (
+    widget.options &&
+    widget.options.property &&
+    node.properties[widget.options.property] !== undefined
+  ) {
+    node.setProperty(widget.options.property, value)
+  }
+  if (widget.callback) {
+    widget.callback(widget.value, app.canvas, node, event)
+  }
+}
+function drawAnnotated(ctx, node, widget_width, y, H) {
+  const litegraph_base = LiteGraph
+  const show_text = app.canvas.ds.scale > 0.5
+  const margin = 15
+  ctx.textAlign = 'left'
+  ctx.strokeStyle = litegraph_base.WIDGET_OUTLINE_COLOR
+  ctx.fillStyle = litegraph_base.WIDGET_BGCOLOR
+  ctx.beginPath()
+  if (show_text)
+    ctx.roundRect(margin, y, widget_width - margin * 2, H, [H * 0.5])
+  else ctx.rect(margin, y, widget_width - margin * 2, H)
+  ctx.fill()
+  if (show_text) {
+    const monospace_font = ctx.font.split(' ')[0] + ' monospace'
+    if (!this.disabled) ctx.stroke()
+    const button = button_action(this)
+    if (button != 'None') {
+      ctx.save()
+      ctx.font = monospace_font
+      if (button.startsWith('No ')) {
+        ctx.fillStyle = litegraph_base.WIDGET_OUTLINE_COLOR
+      } else {
+        ctx.fillStyle = litegraph_base.WIDGET_TEXT_COLOR
+      }
+      if (button.endsWith('Reset')) {
+        ctx.fillText('\u21ba', widget_width - margin - 33, y + H * 0.7)
+      } else {
+        ctx.fillText('\u2298', widget_width - margin - 33, y + H * 0.7)
+      }
+      ctx.restore()
+    }
+    ctx.fillStyle = litegraph_base.WIDGET_TEXT_COLOR
+    if (!this.disabled) {
+      ctx.beginPath()
+      ctx.moveTo(margin + 16, y + 5)
+      ctx.lineTo(margin + 6, y + H * 0.5)
+      ctx.lineTo(margin + 16, y + H - 5)
+      ctx.fill()
+      ctx.beginPath()
+      ctx.moveTo(widget_width - margin - 16, y + 5)
+      ctx.lineTo(widget_width - margin - 6, y + H * 0.5)
+      ctx.lineTo(widget_width - margin - 16, y + H - 5)
+      ctx.fill()
+    }
+    ctx.fillStyle = litegraph_base.WIDGET_SECONDARY_TEXT_COLOR
+    ctx.fillText(this.label || this.name, margin * 2 + 5, y + H * 0.7)
+    ctx.fillStyle = litegraph_base.WIDGET_TEXT_COLOR
+    ctx.textAlign = 'right'
+    const text = Number(this.value).toFixed(
+      this.options.precision !== undefined ? this.options.precision : 3
+    )
+    let value_offset = margin * 2 + 20
+    if (this.options.unit) {
+      ctx.save()
+      ctx.font = monospace_font
+      ctx.fillStyle = litegraph_base.WIDGET_OUTLINE_COLOR
+      ctx.fillText(this.options.unit, widget_width - value_offset, y + H * 0.7)
+      value_offset += ctx.measureText(this.options.unit).width
+      ctx.restore()
+    }
+    ctx.fillText(text, widget_width - value_offset, y + H * 0.7)
+
+    const value_width = ctx.measureText(text).width
+    const name_width = ctx.measureText(this.label || this.name).width
+    const free_width =
+      widget_width - (value_width + name_width + value_offset + 40)
+
+    let annotation = ''
+    if (this.annotation) {
+      annotation = this.annotation(this.value, free_width)
+    } else if (
+      this.options.annotation &&
+      this.value in this.options.annotation
+    ) {
+      annotation = this.options.annotation[this.value]
+    }
+    if (annotation) {
+      ctx.fillStyle = litegraph_base.WIDGET_OUTLINE_COLOR
+      const annotation_width = ctx.measureText(annotation).width
+      if (free_width < annotation_width) {
+        //Enforcing a widget's requested minimum width seems ill supported
+        //hiding annotation is best, but existence should still be indicated
+        annotation = '…'
+      }
+      ctx.fillText(
+        annotation,
+        widget_width - 5 - value_width - value_offset,
+        y + H * 0.7
+      )
+    }
+  }
+}
+function mouseAnnotated(event, [x, y], node) {
+  const button = button_action(this)
+  const widget_width = this.width || node.size[0]
+  const old_value = this.value
+  const delta = x < 40 ? -1 : x > widget_width - 48 ? 1 : 0
+  const margin = 15
+  var allow_scroll = true
+  if (delta) {
+    if (x > -3 && x < widget_width + 3) {
+      allow_scroll = false
+    }
+  }
+  if (allow_scroll && event.type == 'pointermove') {
+    if (event.deltaX)
+      this.value += event.deltaX * 0.1 * (this.options.step || 1)
+    if (this.options.min != null && this.value < this.options.min) {
+      this.value = this.options.min
+    }
+    if (this.options.max != null && this.value > this.options.max) {
+      this.value = this.options.max
+    }
+  } else if (event.type == 'pointerdown') {
+    if (x > widget_width - margin - 34 && x < widget_width - margin - 18) {
+      if (button == 'Reset') {
+        this.value = this.options.reset
+      } else if (button == 'Disable') {
+        this.value = this.options.disable
+      }
+    } else {
+      this.value += delta * 0.1 * (this.options.step || 1)
+      if (this.options.min != null && this.value < this.options.min) {
+        this.value = this.options.min
+      }
+      if (this.options.max != null && this.value > this.options.max) {
+        this.value = this.options.max
+      }
+    }
+  } //end mousedown
+  else if (event.type == 'pointerup') {
+    if (event.click_time < 200 && delta == 0) {
+      app.canvas.prompt(
+        'Value',
+        this.value,
+        function (v) {
+          //NOTE: Original code uses eval here. This will not be reproduced
+          this.value = Number(v)
+          inner_value_change(this, this.value, node, [x, y])
+        }.bind(this),
+        event
+      )
+    }
+  }
+
+  if (old_value != this.value)
+    setTimeout(
+      function () {
+        inner_value_change(this, this.value, node, [x, y])
+      }.bind(this),
+      20
+    )
+  return true
+}
+function makeAnnotated(widget, baseOptions) {
+    Object.assign(widget, {
+        type: 'annotatedNumber',
+        draw: drawAnnotated,
+        mouse: mouseAnnotated,
+        computeSize(width) {
+            return [width, 20]
+        },
+        options: Object.assign({},  baseOptions, widget.options)
+    })
+    return widget
+}
 let latentPreviewNodes = new Set()
 app.registerExtension({
     name: "VideoHelperSuite.Core",
@@ -1443,6 +1651,8 @@ app.registerExtension({
                         }
                         if (w?.type == "text" && config[1].vhs_path_extensions) {
                             new_widgets.push(app.widgets.VHSPATH({}, w.name, ["VHSPATH", config[1]]));
+                        } else if (w?.type == "number") {
+                            new_widgets.push(makeAnnotated(w, config[1]))
                         } else {
                             new_widgets.push(w)
                         }
@@ -1659,6 +1869,14 @@ app.registerExtension({
                 }
                 node.widgets.push(w);
                 return w;
+            },
+            VHSFLOAT(node, inputName, inputData, app) {
+                let w = app.widgets.FLOAT(node, inputName, inputData, app)
+                return makeAnnotated(w, inputData[1]);
+            },
+            VHSINT(node, inputName, inputData, app_arg) {
+                let w = app.widgets.INT(node, inputName, inputData, app)
+                return makeAnnotated(w, inputData[1]);
             }
         }
     },

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1537,14 +1537,14 @@ function makeAnnotated(widget, inputData) {
             return [width, 20]
         },
         callback(v) {
+            if (v == 0) {
+                return
+            }
             if (this.options?.mod == undefined) {
                 return callback_orig.apply(this, arguments);
             }
             const s = this.options.step / 10
             let sh = this.options.mod
-            if (isNaN(sh)) {
-                sh = 0
-            }
             this.value = Math.round((v - sh) / s) * s + sh
         },
         config: inputData,

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -679,23 +679,22 @@ function initializeLoadFormat(nodeType, nodeData) {
         });
         let capWidget = this.widgets.find((w) => w.name === "frame_load_cap")
         let previewWidget = this.widgets.find((w) => w.name === "videopreview")
-        let rateWidget = this.widgets.find((w) => w.name === "force_rate")
         chainCallback(previewWidget, "updateSource", () => setTimeout(async () => {
             if (!previewWidget?.value?.params?.filename) {
                 return
             }
             let qurl = api.apiURL('/vhs/queryvideo?' + new URLSearchParams(previewWidget.value.params))
-            let query_res = await fetch(qurl)
-            let query = await query_res.json()
-            if (!query?.source) {
+            let query = undefined
+            try {
+                let query_res = await fetch(qurl)
+                query = await query_res.json()
+            } catch(e) {
                 return
             }
-            if (rateWidget.value) {
-                let duration = query['source']['duration']
-                this.max_frames = duration * rateWidget.value | 0
-            } else {
-                this.max_frames = query['source']['frames']
+            if (!query?.loaded) {
+                return
             }
+            this.max_frames = query.loaded.frames
         }, 100));
         capWidget.annotation = (value, width) => {
             if (!this.max_frames || value && value < this.max_frames) {

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -652,6 +652,12 @@ function initializeLoadFormat(nodeType, nodeData) {
             if ('dim' in format) {
                 format.custom_width = {'step': format.dim[0]*10, 'mod': format.dim[1]}
                 format.custom_height = {'step': format.dim[0]*10, 'mod': format.dim[1]}
+                if (format.dim[2]) {
+                    format.custom_width.reset = format.dim[2]
+                }
+                if (format.dim[3]) {
+                    format.custom_height.reset = format.dim[3]
+                }
             }
             if ('frames' in format) {
                 format.frame_load_cap = {'step': format.frames[0]*10, 'mod': format.frames[1]}

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -942,6 +942,7 @@ function addVideoPreview(nodeType, isInput=true) {
                     let ar = params.custom_width/params.custom_height
                     params.force_size = target_width+"x"+(target_width/ar)
                 }
+                params.deadline = app.ui.settings.getSettingValue("VHS.AdvancedPreviewsDeadline")
                 if (advp == 'Never' || advp == 'Input Only' && !isInput) {
                     this.videoEl.src = api.apiURL('/view?' + new URLSearchParams(params));
                 } else {
@@ -1627,6 +1628,15 @@ app.registerExtension({
           max: 3840,
         },
         defaultValue: 0,
+      },
+      {
+        id: 'VHS.AdvancedPreviewsDeadline',
+        category: ['🎥🅥🅗🅢', 'Previews', 'Deadline'],
+        name: 'Deadline',
+        tooltip: 'Determines how much time can be spent when encoding advanced previews. Realtime results in reduced quality, but good will likely cause the preview to stutter as initial generation occurs',
+        type: 'combo',
+        options: ['realtime', 'good'],
+        defaultValue: 'realtime',
       },
       {
         id: 'VHS.AdvancedPreviewsDefaultMute',

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1205,7 +1205,6 @@ function addLoadCommon(nodeType, nodeData) {
             'custom_width': updateAR, 'custom_height': updateAR,
             'image_load_cap': 'image_load_cap', 'skip_first_images': 'skip_first_images'
         }
-        let updated = []
         for (let widget of this.widgets) {
             if (widget.name in widgetMap) {
                 if (typeof(widgetMap[widget.name]) == 'function') {
@@ -1213,7 +1212,9 @@ function addLoadCommon(nodeType, nodeData) {
                 } else {
                     chainCallback(widget, "callback", update(widgetMap[widget.name]))
                 }
-                updated.push(widget)
+            }
+            if (widget.type != "button") {
+                widget.callback?.(widget.value)
             }
         }
     });

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -702,11 +702,8 @@ function initializeLoadFormat(nodeType, nodeData) {
                 return
             }
             let format = formatWidget.options.formats[formatWidget.value]
-            if (!format?.frames?.[0]) {
-                return
-            }
-            const div = format.frames[0]
-            const mod = format.frames[1] ?? 0
+            const div = format?.frames?.[0] ?? 1
+            const mod = format?.frames?.[1] ?? 0
             let loadable_frames = this.max_frames
             if ((this.max_frames % div) != mod) {
                 loadable_frames = ((this.max_frames - mod)/div|0) * div + mod


### PR DESCRIPTION
Another large batch of changes.
- Adds additional preview options including a new default that only uses advanced previews for inputs.
- Migrates settings to the new interface for better grouping.
- Adds widget annotation code which provides indicators for things like disabling a widget by setting it to 0.
  - Phase out force_size. It's overly clunky and doesn't scale well as the scene shifts away from AnimateDiff.  Instead, setting custom_width or custom_height to a number other than 0 enables resizing.
  - FLOAT widgets will now accept connections from both INT and FLOAT when converted.
- Add load formats. These will restrict widget values and suggestions to match the recommendations of the current format
- Add a queryvideo endpoint for fetching information about a video file.
  - Add an indicator to frame_load_cap if it is greater than the actual number of frames that can be loaded.
![LoadFormat](https://github.com/user-attachments/assets/93bf94ba-b7dd-4f11-b6ea-047e2e00e1d2)

