### PR TITLE
Output options and cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-videohelpersuite"
 description = "Nodes related to video workflows"
-version = "1.5.0"
+version = "1.5.1"
 license = { file = "LICENSE" }
 dependencies = ["opencv-python", "imageio-ffmpeg"]
 

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -338,11 +338,13 @@ class VideoCombine:
         # save first frame as png to keep metadata
         first_image_file = f"{filename}_{counter:05}.png"
         file_path = os.path.join(full_output_folder, first_image_file)
-        Image.fromarray(tensor_to_bytes(first_image)).save(
-            file_path,
-            pnginfo=metadata,
-            compress_level=4,
-        )
+        extra_options = extra_pnginfo.get('workflow', {}).get('extra', {})
+        if extra_options.get('VHS_MetadataImage', True) != False:
+            Image.fromarray(tensor_to_bytes(first_image)).save(
+                file_path,
+                pnginfo=metadata,
+                compress_level=4,
+            )
         output_files.append(file_path)
 
         format_type, format_ext = format.split("/")
@@ -554,7 +556,10 @@ class VideoCombine:
                 #Return this file with audio to the webui.
                 #It will be muted unless opened or saved with right click
                 file = output_file_with_audio
-
+        if extra_options.get('VHS_KeepIntermediate', True) == False:
+            for intermediate in output_files[1:-1]:
+                if os.path.exists(intermediate):
+                    os.remove(intermediate)
         preview = {
                 "filename": file,
                 "subfolder": subfolder,

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1081,7 +1081,8 @@ function addPreviewOptions(nodeType) {
         options.unshift(...optNew);
     });
 }
-function addFormatWidgets(nodeType) {
+function addFormatWidgets(nodeType, nodeData) {
+    const formats = nodeData?.input?.required?.format?.[1]?.formats
     function parseFormats(options) {
         options.fullvalues = options._values;
         options._values = [];
@@ -1122,11 +1123,12 @@ function addFormatWidgets(nodeType) {
                 formatWidget._value = value;
                 let newWidgets = [];
                 const fullDef = formatWidget.options.fullvalues.find((w) => Array.isArray(w) ? w[0] === value : w === value);
-                if (!Array.isArray(fullDef)) {
+
+                if (!Array.isArray(fullDef) && !formats?.[value]) {
                     formatWidget._value = value;
                 } else {
-                    formatWidget._value = fullDef[0];
-                    let formatWidgets = formatWidgetoptions?.formats?.[fullDef[0]] ?? fullDef[1]
+                    formatWidget._value = value;
+                    let formatWidgets = formats?.[value] ?? fullDef[1]
                     for (let wDef of formatWidgets) {
                         //create widgets. Heavy borrowed from web/scripts/app.js
                         //default implementation doesn't work since it automatically adds
@@ -1844,7 +1846,7 @@ app.registerExtension({
             });
             addVideoPreview(nodeType, false);
             addPreviewOptions(nodeType);
-            addFormatWidgets(nodeType);
+            addFormatWidgets(nodeType, nodeData);
             addVAEInputToggle(nodeType, nodeData)
 
             chainCallback(nodeType.prototype, "onNodeCreated", function() {

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1675,6 +1675,20 @@ app.registerExtension({
           'Force a specific frame rate for the playback of latent frames. This should not be confused with the output frame rate and will not match for video models.',
         defaultValue: 0,
       },
+      {
+        id: 'VHS.MetadataImage',
+        category: ['🎥🅥🅗🅢', 'Output', 'MetadataImage'],
+        name: 'Save png of first frame for metadata',
+        type: 'boolean',
+        defaultValue: true,
+      },
+      {
+        id: 'VHS.KeepIntermediate',
+        category: ['🎥🅥🅗🅢', 'Output', 'Keep Intermediate'],
+        name: 'Keep required intermediate files after sucessful execution',
+        type: 'boolean',
+        defaultValue: true,
+      },
     ],
 
     async beforeRegisterNodeDef(nodeType, nodeData, app) {
@@ -1983,6 +1997,8 @@ app.registerExtension({
             }
             res.workflow.extra['VHS_latentpreview'] = app.ui.settings.getSettingValue("VHS.LatentPreview")
             res.workflow.extra['VHS_latentpreviewrate'] = app.ui.settings.getSettingValue("VHS.LatentPreviewRate")
+            res.workflow.extra['VHS_MetadataImage'] = app.ui.settings.getSettingValue("VHS.MetadataImage")
+            res.workflow.extra['VHS_KeepIntermediate'] = app.ui.settings.getSettingValue("VHS.KeepIntermediate")
             return res
         }
         app.graphToPrompt = graphToPrompt

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1126,7 +1126,8 @@ function addFormatWidgets(nodeType) {
                     formatWidget._value = value;
                 } else {
                     formatWidget._value = fullDef[0];
-                    for (let wDef of fullDef[1]) {
+                    let formatWidgets = formatWidgetoptions?.formats?.[fullDef[0]] ?? fullDef[1]
+                    for (let wDef of formatWidgets) {
                         //create widgets. Heavy borrowed from web/scripts/app.js
                         //default implementation doesn't work since it automatically adds
                         //the widget in the wrong spot.


### PR DESCRIPTION
Adds webui settings to always cleanup non-final outputs and and skip saving of the first frame metadata png
- These files are still listed in output_filenames so that behaviour is consistent with a prune outputs node executing before another consumer of the filenames output
Prep work for cleaning up format widget names
- Every single change that has required syncronization between front and backend has had reported issues from users who do not reload the page. By supporting both and holding off for a week or so, I'm confident that all users will be running updated frontend code before the backend change is made
- Changing the Video Combine formats widget to have simple format names as options should be the final required step to let VHS be functional even when no VHS JS exists.
Server subprocess calls now use asyncio
- Reads are supposed to be non-blocking, but the initial process creation and read were blocking the ComfyUI async event queue. This solves likely painful performance hicks that were not easily attributed back to VHS.
The built-in VHS video_formats folder is no longer included as a folder path and instead prioritized over any formats supplied by folder paths