### PR TITLE
video_format migration and input caching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-videohelpersuite"
 description = "Nodes related to video workflows"
-version = "1.5.1"
+version = "1.5.2"
 license = { file = "LICENSE" }
 dependencies = ["opencv-python", "imageio-ffmpeg"]
 

--- a/videohelpersuite/documentation.py
+++ b/videohelpersuite/documentation.py
@@ -1,7 +1,7 @@
 from .logger import logger
 
 def image(src):
-    return f'<img src={src} style="width: 0px; min-width: 100%">'
+    return f'<img src={src} loading=lazy style="width: 0px; min-width: 100%">'
 def video(src):
     return f'<video preload="none" src={src} muted loop controls controlslist="nodownload noremoteplayback noplaybackrate" style="width: 0px; min-width: 100%" class="VHS_loopedvideo">'
 def short_desc(desc):

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -55,6 +55,7 @@ def get_video_formats():
             continue
         format_files[item.name[:-5]] = item.path
     formats = []
+    format_widgets = {}
     for format_name, path in format_files.items():
         with open(path, 'r') as stream:
             video_format = json.load(stream)
@@ -62,11 +63,10 @@ def get_video_formats():
             #Skip format
             continue
         widgets = [w[0] for w in gen_format_widgets(video_format)]
+        formats.append("video/" + format_name)
         if (len(widgets) > 0):
-            formats.append(["video/" + format_name, widgets])
-        else:
-            formats.append("video/" + format_name)
-    return formats
+            format_widgets["video/"+ format_name] = widgets
+    return formats, format_widgets
 
 def apply_format_widgets(format_name, kwargs):
     if os.path.exists(os.path.join(base_formats_dir, format_name + ".json")):
@@ -206,7 +206,7 @@ def to_pingpong(inp):
 class VideoCombine:
     @classmethod
     def INPUT_TYPES(s):
-        ffmpeg_formats = get_video_formats()
+        ffmpeg_formats, format_widgets = get_video_formats()
         return {
             "required": {
                 "images": (imageOrLatent,),
@@ -216,7 +216,7 @@ class VideoCombine:
                 ),
                 "loop_count": ("INT", {"default": 0, "min": 0, "max": 100, "step": 1}),
                 "filename_prefix": ("STRING", {"default": "AnimateDiff"}),
-                "format": (["image/gif", "image/webp"] + ffmpeg_formats,),
+                "format": (["image/gif", "image/webp"] + ffmpeg_formats, {'formats': format_widgets}),
                 "pingpong": ("BOOLEAN", {"default": False}),
                 "save_output": ("BOOLEAN", {"default": True}),
             },

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -22,7 +22,7 @@ from .load_images_nodes import LoadImagesFromDirectoryUpload, LoadImagesFromDire
 from .batched_nodes import VAEEncodeBatched, VAEDecodeBatched
 from .utils import ffmpeg_path, get_audio, hash_path, validate_path, requeue_workflow, \
         gifski_path, calculate_file_hash, strip_path, try_download_video, is_url, \
-        imageOrLatent, BIGMAX, merge_filter_args, ENCODE_ARGS, floatOrInt
+        imageOrLatent, BIGMAX, merge_filter_args, ENCODE_ARGS, floatOrInt, cached
 from comfy.utils import ProgressBar
 
 if 'VHS_video_formats' not in folder_paths.folder_names_and_paths:
@@ -46,6 +46,7 @@ def gen_format_widgets(video_format):
                 video_format[k] = item[0]
 
 base_formats_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "video_formats")
+@cached(5)
 def get_video_formats():
     format_files = {}
     for format_name in folder_paths.get_filename_list("VHS_video_formats"):

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -583,9 +583,6 @@ class VideoCombine:
             preview['format'] = 'image/png'
             preview['filename'] = file.replace('%03d', '001')
         return {"ui": {"gifs": [preview]}, "result": ((save_output, output_files),)}
-    @classmethod
-    def VALIDATE_INPUTS(self, format, **kwargs):
-        return True
 
 class LoadAudio:
     @classmethod

--- a/videohelpersuite/utils.py
+++ b/videohelpersuite/utils.py
@@ -4,6 +4,7 @@ from typing import Iterable
 import shutil
 import subprocess
 import re
+import time
 from collections.abc import Mapping
 from typing import Union
 import functools
@@ -403,3 +404,15 @@ def hook(obj, attr):
         return f
     return dec
 
+def cached(duration):
+    def dec(f):
+        cached_ret = None
+        cache_time = 0
+        def cached_func():
+            nonlocal cache_time, cached_ret
+            if time.time() > cache_time + duration or cached_ret is None:
+                cache_time = time.time()
+                cached_ret = f()
+            return cached_ret
+        return cached_func
+    return dec

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -20,27 +20,6 @@ function chainCallback(object, property, callback) {
     }
 }
 
-function injectHidden(widget) {
-    widget.computeSize = (target_width) => {
-        if (widget.hidden) {
-            return [0, -4];
-        }
-        return [target_width, 20];
-    };
-    widget._type = widget.type
-    Object.defineProperty(widget, "type", {
-        set : function(value) {
-            widget._type = value;
-        },
-        get : function() {
-            if (widget.hidden) {
-                return "hidden";
-            }
-            return widget._type;
-        }
-    });
-}
-
 const convDict = {
     VHS_LoadImages : ["directory", null, "image_load_cap", "skip_first_images", "select_every_nth"],
     VHS_LoadImagesPath : ["directory", "image_load_cap", "skip_first_images", "select_every_nth"],

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1082,17 +1082,6 @@ function addPreviewOptions(nodeType) {
     });
 }
 function addFormatWidgets(nodeType, nodeData) {
-    function parseFormats(options) {
-        options.fullvalues = options._values;
-        options._values = [];
-        for (let format of options.fullvalues) {
-            if (Array.isArray(format)) {
-                options._values.push(format[0]);
-            } else {
-                options._values.push(format);
-            }
-        }
-    }
     chainCallback(nodeType.prototype, "onNodeCreated", function() {
         var formatWidget = null;
         var formatWidgetIndex = -1;
@@ -1100,76 +1089,31 @@ function addFormatWidgets(nodeType, nodeData) {
             if (this.widgets[i].name === "format"){
                 formatWidget = this.widgets[i];
                 formatWidgetIndex = i+1;
+                break
             }
         }
         let formatWidgetsCount = 0;
         //Pre-process options to just names
-        formatWidget.options._values = formatWidget.options.values;
-        parseFormats(formatWidget.options);
-        Object.defineProperty(formatWidget.options, "values", {
-            set : (value) => {
-                formatWidget.options._values  = value;
-                parseFormats(formatWidget.options);
-            },
-            get : () => {
-                return formatWidget.options._values;
-            }
-        })
-
-        formatWidget._value = formatWidget.value;
-        Object.defineProperty(formatWidget, "value", {
-            set : (value) => {
-                const formats = (LiteGraph.registered_node_types[this.type]
-                    ?.nodeData?.input?.required?.format?.[1]?.formats)
-                formatWidget._value = value;
-                let newWidgets = [];
-                const fullDef = formatWidget.options.fullvalues.find((w) => Array.isArray(w) ? w[0] === value : w === value);
-
-                if (!Array.isArray(fullDef) && !formats?.[value]) {
-                    formatWidget._value = value;
-                } else {
-                    formatWidget._value = value;
-                    let formatWidgets = formats?.[value] ?? fullDef[1]
-                    for (let wDef of formatWidgets) {
-                        //create widgets. Heavy borrowed from web/scripts/app.js
-                        //default implementation doesn't work since it automatically adds
-                        //the widget in the wrong spot.
-                        //TODO: consider letting this happen and just removing from list?
-                        let w = {};
-                        w.name = wDef[0];
-                        w.config = wDef.slice(1);
-                        let inputData = wDef.slice(1);
-                        w.type = inputData[0];
-                        w.options = inputData[1] ? inputData[1] : {};
-                        if (Array.isArray(w.type)) {
-                            w.value = w.type[0];
-                            w.options.values = w.type;
-                            w.type = "combo";
-                        }
-                        if(inputData[1]?.default != undefined) {
-                            w.value = inputData[1].default;
-                        }
-                        if (w.type == "INT") {
-                            Object.assign(w.options, {"precision": 0, "step": 10})
-                            w.callback = function (v) {
-                                const s = this.options.step / 10;
-                                this.value = Math.round(v / s) * s;
-                            }
-                        }
-                        const typeTable = {BOOLEAN: "toggle", STRING: "text", INT: "number", FLOAT: "number"};
-                        if (w.type in typeTable) {
-                            w.type = typeTable[w.type];
-                        }
-                        newWidgets.push(w);
+        chainCallback(formatWidget, "callback", (value) => {
+            const formats = (LiteGraph.registered_node_types[this.type]
+                ?.nodeData?.input?.required?.format?.[1]?.formats)
+            let newWidgets = [];
+            if (formats?.[value]) {
+                let formatWidgets = formats[value]
+                for (let wDef of formatWidgets) {
+                    let type = wDef[1]
+                    if (Array.isArray(type)) {
+                        type = "COMBO"
                     }
+                    app.widgets[type](this, wDef[0], wDef.slice(1), app)
+                    let w = this.widgets.pop()
+                    w.config = wDef.slice(1)
+                    newWidgets.push(w)
                 }
-                this.widgets.splice(formatWidgetIndex, formatWidgetsCount, ...newWidgets);
-                fitHeight(this);
-                formatWidgetsCount = newWidgets.length;
-            },
-            get : () => {
-                return formatWidget._value;
             }
+            this.widgets.splice(formatWidgetIndex, formatWidgetsCount, ...newWidgets);
+            fitHeight(this);
+            formatWidgetsCount = newWidgets.length;
         });
     });
 }

--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1082,7 +1082,6 @@ function addPreviewOptions(nodeType) {
     });
 }
 function addFormatWidgets(nodeType, nodeData) {
-    const formats = nodeData?.input?.required?.format?.[1]?.formats
     function parseFormats(options) {
         options.fullvalues = options._values;
         options._values = [];
@@ -1120,6 +1119,8 @@ function addFormatWidgets(nodeType, nodeData) {
         formatWidget._value = formatWidget.value;
         Object.defineProperty(formatWidget, "value", {
             set : (value) => {
+                const formats = (LiteGraph.registered_node_types[this.type]
+                    ?.nodeData?.input?.required?.format?.[1]?.formats)
                 formatWidget._value = value;
                 let newWidgets = [];
                 const fullDef = formatWidget.options.fullvalues.find((w) => Array.isArray(w) ? w[0] === value : w === value);


### PR DESCRIPTION
Video Formats are no longer stored in combo item names. This change was staged to be functional even if the webpage isn't refreshed. With this change applied, VHS nodes are now usable with reduced functionality even when front end js does not load.

The INPUT_TYPES method of Video Combine is now cached to reduce disk reads.