### PR TITLE
Support Core format for video metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-videohelpersuite"
 description = "Nodes related to video workflows"
-version = "1.5.2"
+version = "1.5.3"
 license = { file = "LICENSE" }
 dependencies = ["opencv-python", "imageio-ffmpeg"]
 

--- a/web/js/videoinfo.js
+++ b/web/js/videoinfo.js
@@ -25,13 +25,16 @@ function getVideoMetadata(file) {
                     if (dataView.getUint16(offset) == 0x4487) {
                         //check that name of tag is COMMENT
                         const name = String.fromCharCode(...videoData.slice(offset-7,offset));
-                        if (name === "COMMENT") {
+                        if (name === "COMMENT" || name === "ORKFLOW") {
                             let vint = dataView.getUint32(offset+2);
                             let n_octets = Math.clz32(vint)+1;
                             if (n_octets < 4) {//250MB sanity cutoff
                                 let length = (vint >> (8*(4-n_octets))) & ~(1 << (7*n_octets));
                                 const content = decoder.decode(videoData.slice(offset+2+n_octets, offset+2+n_octets+length));
-                                const json = JSON.parse(content);
+                                let json = JSON.parse(content);
+                                if (name === "COMMENT") {
+                                    json = json.workflow
+                                }
                                 r(json);
                                 return;
                             }
@@ -91,11 +94,7 @@ async function handleFile(file) {
     if (file?.type?.startsWith("video/") || isVideoFile(file)) {
         const videoInfo = await getVideoMetadata(file);
         if (videoInfo) {
-            if (videoInfo.workflow) {
-
-                app.loadGraphData(videoInfo.workflow);
-            }
-            //Potentially check for/parse A1111 metadata here.
+            app.loadGraphData(videoInfo);
         }
     } else {
         return await originalHandleFile.apply(this, arguments);


### PR DESCRIPTION
Core has added experimental support for outputting video, but does not support loading it yet. VHS currently swallows any video files it can not find metadata in. Once ComfyUI adds support for loading it's own video files, this will result in an awkward period where VHS breaks loading of core ComfyUI video files.

Instead, I've just implemented support for loading workflows from videos output by ComfyUI.

Once there's a core implementation for loading, I plan to instead pass video files not in VHS format for safety.