### PR TITLE
Fix loading of mp4 metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-videohelpersuite"
 description = "Nodes related to video workflows"
-version = "1.5.3"
+version = "1.5.4"
 license = { file = "LICENSE" }
 dependencies = ["opencv-python", "imageio-ffmpeg"]
 

--- a/web/js/videoinfo.js
+++ b/web/js/videoinfo.js
@@ -32,8 +32,8 @@ function getVideoMetadata(file) {
                                 let length = (vint >> (8*(4-n_octets))) & ~(1 << (7*n_octets));
                                 const content = decoder.decode(videoData.slice(offset+2+n_octets, offset+2+n_octets+length));
                                 let json = JSON.parse(content);
-                                if (name === "COMMENT") {
-                                    json = json.workflow
+                                if (name === "ORKFLOW") {
+                                    json = {workflow: json}
                                 }
                                 r(json);
                                 return;
@@ -93,8 +93,8 @@ fileInput.accept += ",video/webm,video/mp4";
 async function handleFile(file) {
     if (file?.type?.startsWith("video/") || isVideoFile(file)) {
         const videoInfo = await getVideoMetadata(file);
-        if (videoInfo) {
-            app.loadGraphData(videoInfo);
+        if (videoInfo?.workflow) {
+            await app.loadGraphData(videoInfo.workflow);
         }
     } else {
         return await originalHandleFile.apply(this, arguments);


### PR DESCRIPTION
mp4 files are parsed separately from webm files. The prior commit changed the parsing to directly pass the workflow content, but failed to make an equivalent change in the mp4 parsing code.

As a fix, the full dict containing metadata information is now returned as before and native videos are simply wrapped.