### PR TITLE
Fix `query_video` always raising an exception for WebP.

### DIFF
--- a/videohelpersuite/server.py
+++ b/videohelpersuite/server.py
@@ -140,6 +140,9 @@ async def query_video(request):
     if isinstance(filepath, web.Response):
         return filepath
     filepath = filepath[0]
+    if filepath.endswith(".webp"):
+        # ffmpeg doesn't support decoding animated WebP https://trac.ffmpeg.org/ticket/4907
+        return web.json_response({})
     if filepath in query_cache and query_cache[filepath][0] == os.stat(filepath).st_mtime:
         source = query_cache[filepath][1]
     else:


### PR DESCRIPTION
When using `image/webp`, the terminal is always littered with the following errors:

<details>
<summary>Click to see the errors</summary>

```
Error handling request from 127.0.0.1
Traceback (most recent call last):
  File "C:\Apps\ComfyUI\custom_nodes\ComfyUI-VideoHelperSuite\videohelpersuite\server.py", line 151, in query_video
    dummy_res = subprocess.run(args_dummy, stdout=subprocess.DEVNULL,
                             stderr=subprocess.PIPE, check=True)
  File "C:\Apps\Python\Lib\subprocess.py", line 579, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['c:\\apps\\ffmpeg\\bin\\ffmpeg.EXE', '-i', 'C:\\Apps\\ComfyUI\\output\\Wan_720p_00018.webp', '-c', 'copy', '-frames:v', '1', '-f', 'null', '-']' returned non-zero exit status 4294967274.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Apps\Python\Lib\site-packages\aiohttp\web_protocol.py", line 480, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Apps\Python\Lib\site-packages\aiohttp\web_app.py", line 569, in _handle
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Apps\Python\Lib\site-packages\aiohttp\web_middlewares.py", line 117, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Apps\ComfyUI\server.py", line 50, in cache_control
    response: web.Response = await handler(request)
                             ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Apps\ComfyUI\server.py", line 142, in origin_only_middleware
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Apps\ComfyUI\custom_nodes\ComfyUI-VideoHelperSuite\videohelpersuite\server.py", line 154, in query_video
    raise Exception("An error occurred in the ffmpeg subprocess:\n" \
            + e.stderr.decode(*ENCODE_ARGS))
Exception: An error occurred in the ffmpeg subprocess:
ffmpeg version 7.1-full_build-www.gyan.dev Copyright (c) 2000-2024 the FFmpeg developers
  built with gcc 14.2.0 (Rev1, Built by MSYS2 project)
  configuration: --enable-gpl --enable-version3 --enable-static --disable-w32threads --disable-autodetect --enable-fontconfig --enable-iconv --enable-gnutls --enable-libxml2 --enable-gmp --enable-bzlib --enable-lzma --enable-libsnappy --enable-zlib --enable-librist --enable-libsrt --enable-libssh --enable-libzmq --enable-avisynth --enable-libbluray --enable-libcaca --enable-sdl2 --enable-libaribb24 --enable-libaribcaption --enable-libdav1d --enable-libdavs2 --enable-libopenjpeg --enable-libquirc --enable-libuavs3d --enable-libxevd --enable-libzvbi --enable-libqrencode --enable-librav1e --enable-libsvtav1 --enable-libvvenc --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxavs2 --enable-libxeve --enable-libxvid --enable-libaom --enable-libjxl --enable-libvpx --enable-mediafoundation --enable-libass --enable-frei0r --enable-libfreetype --enable-libfribidi --enable-libharfbuzz --enable-liblensfun --enable-libvidstab --enable-libvmaf --enable-libzimg --enable-amf --enable-cuda-llvm --enable-cuvid --enable-dxva2 --enable-d3d11va --enable-d3d12va --enable-ffnvcodec --enable-libvpl --enable-nvdec --enable-nvenc --enable-vaapi --enable-libshaderc --enable-vulkan --enable-libplacebo --enable-opencl --enable-libcdio --enable-libgme --enable-libmodplug --enable-libopenmpt --enable-libopencore-amrwb --enable-libmp3lame --enable-libshine --enable-libtheora --enable-libtwolame --enable-libvo-amrwbenc --enable-libcodec2 --enable-libilbc --enable-libgsm --enable-liblc3 --enable-libopencore-amrnb --enable-libopus --enable-libspeex --enable-libvorbis --enable-ladspa --enable-libbs2b --enable-libflite --enable-libmysofa --enable-librubberband --enable-libsoxr --enable-chromaprint
  libavutil      59. 39.100 / 59. 39.100
  libavcodec     61. 19.100 / 61. 19.100
  libavformat    61.  7.100 / 61.  7.100
  libavdevice    61.  3.100 / 61.  3.100
  libavfilter    10.  4.100 / 10.  4.100
  libswscale      8.  3.100 /  8.  3.100
  libswresample   5.  3.100 /  5.  3.100
  libpostproc    58.  3.100 / 58.  3.100
[webp @ 000001e7b5d4acc0] skipping unsupported chunk: ANIM
[webp @ 000001e7b5d4acc0] skipping unsupported chunk: ANMF
    Last message repeated 32 times
[webp @ 000001e7b5d4acc0] invalid TIFF header in Exif data
[webp @ 000001e7b5d4acc0] image data not found
[webp_pipe @ 000001e7b5d36cc0] Could not find codec parameters for stream 0 (Video: webp, none): unspecified size
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
Input #0, webp_pipe, from 'C:\Apps\ComfyUI\output\Wan_720p_00018.webp':
  Duration: N/A, bitrate: N/A
  Stream #0:0: Video: webp, none, 25 fps, 25 tbr, 25 tbn
Stream mapping:
  Stream #0:0 -> #0:0 (copy)
[null @ 000001e7b6120640] dimensions not set
[out#0/null @ 000001e7b6120540] Could not write header (incorrect codec parameters ?): Invalid argument
Conversion failed!
```
</details>

Among that wall of text we can see the root cause:

```
[webp @ 000001e7b5d4acc0] skipping unsupported chunk: ANIM
[webp @ 000001e7b5d4acc0] skipping unsupported chunk: ANMF
```

Indeed there is a [ffmpeg tracking issue for supporting animated WebP decoding](https://trac.ffmpeg.org/ticket/4907). Alas that support isn't there today.

This PR adds a simple check to skip even trying to use ffmpeg to decode files with a `webp` extension. This helps keep the terminal clear of the repeated error messages.