### PR TITLE
Improve cloneType disconnection logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-videohelpersuite"
 description = "Nodes related to video workflows"
-version = "1.5.13"
+version = "1.5.14"
 license = { file = "LICENSE" }
 dependencies = ["opencv-python", "imageio-ffmpeg"]
 


### PR DESCRIPTION
The prior disconnection logic would eagerly disconnect if the type has changed at all. In addition to providing awful quality of life, this was also causing issue with workflows that contain an unbatch node being saved at all.

The code for type cloning has undergone a substantial rewrite to properly check link validity and to propogate link events