### PR TITLE
Add color space metadata to FFmpeg input.

### DIFF
--- a/video_formats/ProRes.json
+++ b/video_formats/ProRes.json
@@ -3,9 +3,9 @@
     [
         "-n", "-c:v", "prores_ks",
         "-profile:v", ["profile",["1","2","3","4"], {"default": "3"}],
-        "-colorspace", "1", "-color_primaries", "1", "-color_trc", "1"
-
+        "-vf", "scale=out_color_matrix=bt709"
     ],
+    "fake_trc": "bt709",
     "audio_pass": ["-c:a", "pcm_s16le"],
     "extension": "mov"
 }

--- a/video_formats/av1-webm.json
+++ b/video_formats/av1-webm.json
@@ -4,9 +4,9 @@
         "-n", "-c:v", "libsvtav1",
         "-pix_fmt", ["pix_fmt", ["yuv420p10le", "yuv420p"]],
         "-crf", ["crf","INT", {"default": 23, "min": 0, "max": 100, "step": 1}],
-        "-vf", "colorspace=all=bt709:iall=bt601-6-625:fast=1",
-        "-colorspace", "1", "-color_primaries", "1", "-color_trc", "1"
+        "-vf", "scale=out_color_matrix=bt709"
     ],
+    "fake_trc": "bt709",
     "audio_pass": ["-c:a", "libopus"],
     "input_color_depth": ["input_color_depth", ["8bit", "16bit"]],
     "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],

--- a/video_formats/gifski.json
+++ b/video_formats/gifski.json
@@ -1,7 +1,8 @@
 {
     "main_pass":
     [
-        "-pix_fmt", "yuv420p"
+        "-pix_fmt", "yuv420p",
+        "-vf", "scale=out_color_matrix=bt709"
     ],
     "extension": "gif",
     "gifski_pass": [

--- a/video_formats/h264-mp4.json
+++ b/video_formats/h264-mp4.json
@@ -4,9 +4,9 @@
         "-n", "-c:v", "libx264",
         "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le"]],
         "-crf", ["crf","INT", {"default": 19, "min": 0, "max": 100, "step": 1}],
-        "-vf", "colorspace=all=bt709:iall=bt601-6-625:fast=1",
-        "-colorspace", "1", "-color_primaries", "1", "-color_trc", "1"
+        "-vf", "scale=out_color_matrix=bt709"
     ],
+    "fake_trc": "bt709",
     "audio_pass": ["-c:a", "aac"],
     "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],
     "trim_to_audio": ["trim_to_audio", "BOOLEAN", {"default": false}],

--- a/video_formats/h265-mp4.json
+++ b/video_formats/h265-mp4.json
@@ -6,10 +6,10 @@
         "-pix_fmt", ["pix_fmt", ["yuv420p10le", "yuv420p"]],
         "-crf", ["crf","INT", {"default": 22, "min": 0, "max": 100, "step": 1}],
         "-preset", "medium",
-        "-vf", "colorspace=all=bt709:iall=bt601-6-625:fast=1",
-        "-colorspace", "1", "-color_primaries", "1", "-color_trc", "1",
+        "-vf", "scale=out_color_matrix=bt709",
         "-x265-params", "log-level=quiet"
     ],
+    "fake_trc": "bt709",
     "audio_pass": ["-c:a", "aac"],
     "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],
     "extension": "mp4"

--- a/video_formats/nvenc_h264-mp4.json
+++ b/video_formats/nvenc_h264-mp4.json
@@ -2,8 +2,10 @@
     "main_pass":
     [
         "-n", "-c:v", "h264_nvenc",
-        "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le", "rgba"]]
+        "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le", "rgba"]],
+        "-vf", "scale=out_color_matrix=bt709"
     ],
+    "fake_trc": "bt709",
     "audio_pass": ["-c:a", "aac"],
     "bitrate": ["bitrate","INT", {"default": 10, "min": 1, "max": 999, "step": 1 }],
     "megabit": ["megabit","BOOLEAN", {"default": true}],

--- a/video_formats/nvenc_hevc-mp4.json
+++ b/video_formats/nvenc_hevc-mp4.json
@@ -3,8 +3,10 @@
     [
         "-n", "-c:v", "hevc_nvenc",
         "-vtag", "hvc1",
-        "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le", "rgba"]]
+        "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le", "rgba"]],
+        "-vf", "scale=out_color_matrix=bt709"
     ],
+    "fake_trc": "bt709",
     "audio_pass": ["-c:a", "aac"],
     "bitrate": ["bitrate","INT", {"default": 10, "min": 1, "max": 999, "step": 1 }],
     "megabit": ["megabit","BOOLEAN", {"default": true}],

--- a/video_formats/webm.json
+++ b/video_formats/webm.json
@@ -5,8 +5,9 @@
         "-pix_fmt", ["pix_fmt",["yuv420p","yuva420p"]],
         "-crf", ["crf","INT", {"default": 20, "min": 0, "max": 100, "step": 1}],
         "-b:v", "0",
-        "-colorspace", "1", "-color_primaries", "1", "-color_trc", "1"
+        "-vf", "scale=out_color_matrix=bt709"
     ],
+    "fake_trc": "bt709",
     "audio_pass": ["-c:a", "libvorbis"],
     "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],
     "trim_to_audio": ["trim_to_audio", "BOOLEAN", {"default": false}],


### PR DESCRIPTION
## Background

As I was using the `hevc_nvenc` video format I noticed that the video colors were wrong. This led me down a rabbit hole of figuring out what is going on, why the [previous fix for some other formats](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/commit/8893cdc8be222d04839d0c61261ff193acf4d5eb) seems to work, and how to properly address the issue.

## Core issue

We feed `rawvideo` to FFmpeg without providing much metadata about the colors. This leads to FFmpeg having to guess what was given to it. It makes great guesses, but what it doesn't know is that the "video" we feed to it isn't really video, but a series of images. The color space conventions of video vs images are different.

The most common standard used for images is [sRGB](https://en.wikipedia.org/wiki/SRGB) and indeed most software will assume it is dealing with sRGB when no color space info is provided for an image. The color space story around diffusion models is very lacking. As an example, the only mention of color spaces in the [Wan 2.1 paper (pg. 31)](https://arxiv.org/pdf/2503.20314) is that the frames in the model input are in "RGB space". That sort of accuracy is about 25 years behind state-of-the-art, as sRGB was published in 1999. Even so, the best we can do is go by convention and assume sRGB - as most software does - and indeed the official Wan 2.1 code loads images with that assumption. (_**Speculation**: I suspect a lot of mistakes are being made during training, with sRGB, BT.601, BT.709 and others being mixed without proper conversion. Which is sad and probably promotes the color shifts we see in I2V models._)

Coming back to FFmpeg, it has no idea about our sRGB source, sees `rawvideo` without metadata, and [just assumes BT.601](https://github.com/FFmpeg/FFmpeg/blob/4da84d5c2b2b0cd415ef4c514f716784654cee54/libswscale/swscale.h#L375). The result is that the colors in our saved videos look off.

## Original fix

In 8893cdc8be222d04839d0c61261ff193acf4d5eb a fix was added to some formats, by adding the following to the output side of FFmpeg:

`
-vf "colorspace=all=bt709:iall=bt601-6-625:fast=1" -colorspace 1 -color_primaries 1 -color_trc 1
`

First, the `colorspace` filter does this:
* Specifies that output YUV should be BT.709.
* Specifies that input YUV is BT.601.
* Specifies via `fast=1` to skip converting primaries and gamma (trc), to just convert the color space.

Then, finally, the three options with values of `1` just set metadata in the output container that everything is BT.709 (`== 1`).

This does give a result that looks like a match with the source sRGB image. But why and how does it work? Our input is sRGB, not BT.601 YUV, so what's going on here?

Well, as mentioned earlier, FFmpeg makes an educated guess that the source `rawvideo` is BT.601. This fix does nothing to change that. Also, the `colorspace` filter works on YUV data, it doesn't accept RGB. So what happens under the hood is that FFmpeg converts the source RGB data with a BT.601 matrix into YUV (via the `scale` filter) and then feeds that BT.601 YUV into the `colorspace` filter. Then the `colorspace` filter converts this to BT.709 YUV.

The end result looks fine, though there is a tiny bit of quality loss due to the double conversion. Plus, it's a bit slower, because the extra conversion takes time.

## Fundamental fix

Now that we deeply understand the problem, we can introduce a fundamental solution. Instead of re-converting the BT.601 conversion that FFmpeg automatically performs, we can just set the correct metadata on the input so that FFmpeg can directly convert to BT.709. No extra quality loss, no extra conversion time.

Basically we need to move the `-colorspace` / `-color_primaries` / `-color_trc` options from the output side to the input side. Then FFmpeg knows that these apply to the input as well. We don't even need to re-specify them for output, as FFmpeg will carry over the input metadata to the output automatically. We also need to explicitly set the `scale` filter conversion target to BT.709 via `-vf "scale=out_color_matrix=bt709"`. This is what defaults to BT.601.

Then we don't need the `colorspace` filter anymore.

## Getting into the details

Of course nothing is as simple as that. In practice we have a few more details to worry about.

Looking at the basic properties of sRGB, it has the same primaries \[`-color_primaries`\] and matrix \[`-colorspace`\] as BT.709, but a different transfer function (gamma) \[`-color_trc`\], called by the sRGB standard name IEC 61966-2-1. Ideally we would just specify these as the input metadata, but unfortunately we run into two issues when doing so.

FFmpeg seems to execute the `scale` filter four times instead of once if we use `-colorspace bt709`. Not exactly sure why it does that. The resulting pixels are 100% byte-for-byte match with a single run, so the loop doesn't hurt quality. It does seem like wasted work though and there is a straightforward way to do only a single `scale`. We use `-colorspace rgb` instead, which is more accurate for the input anyway, and then FFmpeg will learn of the need to use the BT.709 matrix for the RGB->YUV conversion thanks to our explicit `scale=out_color_matrix=bt709` specification.

Using `-color_trc iec61966-2-1` for sRGB input is absolutely the technically correct choice. The results look visually correct too, no issue with that. However, video hosting platforms like YouTube standardize on full BT.709 and will convert the colors accordingly. Our video primaries and matrix are already BT.709, but the transfer function (gamma) will be converted and so the "brightness" will look slightly different on YouTube. This last minute change can be confusing to users. We can counter it by lying about the transfer function on a per format basis, i.e. for video we will lie to FFmpeg that it is already BT.709. This has no impact one way or another on local viewing and will prevent YouTube from tampering with the gamma. Technically speaking this is some shenanigans, but in practice it provides the least surprising behavior for most people.

## Verifying the solution

Of course nothing beats a full end-to-end test (*which I also did with all the format options*), but let me provide some quick FFmpeg commands that will provide a few test videos to showcase that the new solution provides accurate colors.

First, we'll need a test image. I used an official HDTV test pattern called SMPTE RP 219:2002. The [SVG file](https://upload.wikimedia.org/wikipedia/commons/6/60/SMPTE_Color_Bars_16x9.svg) is available on Wikipedia but I'll also embed a PNG in this post.

<details>
<summary>Click here to see a 1280x720 PNG of SMPTE RP 219:2002</summary>

![bars](https://github.com/user-attachments/assets/5156d0e2-d6bf-4e7d-ab6e-f8f8e93bdfe2)

</details>

Now that we have the PNG, let's create a short `rawvideo` file of it. This is so that we can emulate the scenario where the input has no metadata.

```
ffmpeg -loop 1 -i bars.png -frames:v 10 -framerate 10 -pix_fmt rgb24 -f rawvideo bars.rgb
```

Next, let's generate three videos:

```
ffmpeg -f rawvideo -pix_fmt rgb24 -s 1280x720 -r 10 -i bars.rgb -c:v libx264 -crf 0 -pix_fmt yuv420p bars_auto.mp4

ffmpeg -f rawvideo -pix_fmt rgb24 -s 1280x720 -r 10 -i bars.rgb -vf "colorspace=all=bt709:iall=bt601-6-625:fast=1" -c:v libx264 -crf 0 -pix_fmt yuv420p -colorspace bt709 -color_primaries bt709 -color_trc bt709 bars_original_fix.mp4

ffmpeg -f rawvideo -pix_fmt rgb24 -s 1280x720 -r 10 -color_range full -colorspace rgb -color_primaries bt709 -color_trc bt709 -i bars.rgb -vf "scale=out_color_matrix=bt709" -c:v libx264 -crf 0 -pix_fmt yuv420p bars_new_solution.mp4
```

To compare the results, I found it easiest to just drag the three resulting mp4 files, plus the original `bars.png`, into my Chrome instance and switch between the four tabs. What it shows is that, visually, three of them have the same colors while the fully automatic `bars_auto.mp4` is incorrect. Note that due to the `yuv420` chroma subsampling, none of them look like an exact match compared to the original `bars.png` but that is of course expected. The `bars_original_fix.mp4` and `bars_new_solution.mp4` will look the same to the naked eye.

We can get a hash of the video streams:

```
ffmpeg -i bars_original_fix.mp4 -frames:v 1 -f framemd5 -
ffmpeg -i bars_new_solution.mp4 -frames:v 1 -f framemd5 -
```

This is an easy way to show that the output picture is slightly different, because the original fix lost some quality due to the double conversion.

## Summary

That's a lot of text (*plus research and testing*) for minor changes. The image quality of the original fix was good enough for most people and the double conversion performance loss was negligible. For image exports (e.g. PNG) FFmpeg's automatic guesses were accurate, so it wasn't a problem at this point. In that sense, one could say that the main issue was that the original fix wasn't applied to all the video formats.

However, I think that the fundamental fix is still worth it. It gets to the core of the issue and solves it there. Not only is it slightly better for the current use cases, but it will also be a lot more robust for potential new use cases as FFmpeg usage gets more complicated (e.g. more filters).