### PR TITLE
Remove broken `rgba` support from NVENC formats.

### DIFF
--- a/video_formats/nvenc_h264-mp4.json
+++ b/video_formats/nvenc_h264-mp4.json
@@ -2,7 +2,7 @@
     "main_pass":
     [
         "-n", "-c:v", "h264_nvenc",
-        "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le", "rgba"]]
+        "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le"]]
     ],
     "audio_pass": ["-c:a", "aac"],
     "bitrate": ["bitrate","INT", {"default": 10, "min": 1, "max": 999, "step": 1 }],

--- a/video_formats/nvenc_hevc-mp4.json
+++ b/video_formats/nvenc_hevc-mp4.json
@@ -3,7 +3,7 @@
     [
         "-n", "-c:v", "hevc_nvenc",
         "-vtag", "hvc1",
-        "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le", "rgba"]]
+        "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le"]]
     ],
     "audio_pass": ["-c:a", "aac"],
     "bitrate": ["bitrate","INT", {"default": 10, "min": 1, "max": 999, "step": 1 }],


### PR DESCRIPTION
The `rgba` options for both `h264_nvenc` and `hevc_nvenc` are broken. They have incorrect colors and more importantly don't actually have any alpha.

According to [NVENC SDK docs](https://docs.nvidia.com/video-technologies/video-codec-sdk/13.0/nvenc-video-encoder-api-prog-guide/index.html#hevc-alpha-encoding) the H.264 encoder doesn't support alpha even in theory, while the HEVC encoder does support it in theory.

However, in practice FFmpeg does not support HEVC alpha, so we're out of luck once again. There is an [FFmpeg HEVC alpha tracking issue](https://trac.ffmpeg.org/ticket/7965) which promises some HEVC alpha support via `libx265` in the future. Alas, right now we have nothing.

This PR removes the broken `rgba` option from the NVENC formats, as choosing it will only produce lower quality results with no alpha that can only serve to confuse users.

Closes #440