### PR TITLE
Increase the quality of the YUV4MPEG2 pipe stream to Gifski.

### DIFF
--- a/video_formats/gifski.json
+++ b/video_formats/gifski.json
@@ -1,8 +1,9 @@
 {
     "main_pass":
     [
-        "-pix_fmt", "yuv420p",
-        "-vf", "scale=out_color_matrix=bt709"
+        "-pix_fmt", "yuv444p",
+        "-vf", "scale=out_color_matrix=bt709:out_range=pc",
+        "-color_range", "pc"
     ],
     "extension": "gif",
     "gifski_pass": [


### PR DESCRIPTION
Gifski is capable of accepting a higher quality input stream. We can go from limited to full color range, and from 420 to 444. This doesn't change any metadata in the final GIF as it's just about the source, but it will produce a more accurate final representation of the image.

Here is an example PNG that is based on Gifski results. The image contains four different horizontal gradients. From top to bottom, the ordering is 420 limited, 420 full, 444 full, original PNG.

![four-gradients](https://github.com/user-attachments/assets/7cfb7cc8-a158-490f-81bd-c724a96e5ef2)
