### PR TITLE
Add explicit color space metadata for FFmpeg 4.2 output.

### DIFF
--- a/video_formats/ProRes.json
+++ b/video_formats/ProRes.json
@@ -3,7 +3,8 @@
     [
         "-n", "-c:v", "prores_ks",
         "-profile:v", ["profile",["1","2","3","4"], {"default": "3"}],
-        "-vf", "scale=out_color_matrix=bt709"
+        "-vf", "scale=out_color_matrix=bt709",
+        "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],
     "fake_trc": "bt709",
     "audio_pass": ["-c:a", "pcm_s16le"],

--- a/video_formats/av1-webm.json
+++ b/video_formats/av1-webm.json
@@ -4,7 +4,8 @@
         "-n", "-c:v", "libsvtav1",
         "-pix_fmt", ["pix_fmt", ["yuv420p10le", "yuv420p"]],
         "-crf", ["crf","INT", {"default": 23, "min": 0, "max": 100, "step": 1}],
-        "-vf", "scale=out_color_matrix=bt709"
+        "-vf", "scale=out_color_matrix=bt709",
+        "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],
     "fake_trc": "bt709",
     "audio_pass": ["-c:a", "libopus"],

--- a/video_formats/h264-mp4.json
+++ b/video_formats/h264-mp4.json
@@ -4,7 +4,8 @@
         "-n", "-c:v", "libx264",
         "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le"]],
         "-crf", ["crf","INT", {"default": 19, "min": 0, "max": 100, "step": 1}],
-        "-vf", "scale=out_color_matrix=bt709"
+        "-vf", "scale=out_color_matrix=bt709",
+        "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],
     "fake_trc": "bt709",
     "audio_pass": ["-c:a", "aac"],

--- a/video_formats/h265-mp4.json
+++ b/video_formats/h265-mp4.json
@@ -6,8 +6,9 @@
         "-pix_fmt", ["pix_fmt", ["yuv420p10le", "yuv420p"]],
         "-crf", ["crf","INT", {"default": 22, "min": 0, "max": 100, "step": 1}],
         "-preset", "medium",
+        "-x265-params", "log-level=quiet",
         "-vf", "scale=out_color_matrix=bt709",
-        "-x265-params", "log-level=quiet"
+        "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],
     "fake_trc": "bt709",
     "audio_pass": ["-c:a", "aac"],

--- a/video_formats/nvenc_h264-mp4.json
+++ b/video_formats/nvenc_h264-mp4.json
@@ -3,7 +3,8 @@
     [
         "-n", "-c:v", "h264_nvenc",
         "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le"]],
-        "-vf", "scale=out_color_matrix=bt709"
+        "-vf", "scale=out_color_matrix=bt709",
+        "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],
     "fake_trc": "bt709",
     "audio_pass": ["-c:a", "aac"],

--- a/video_formats/nvenc_hevc-mp4.json
+++ b/video_formats/nvenc_hevc-mp4.json
@@ -4,7 +4,8 @@
         "-n", "-c:v", "hevc_nvenc",
         "-vtag", "hvc1",
         "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le"]],
-        "-vf", "scale=out_color_matrix=bt709"
+        "-vf", "scale=out_color_matrix=bt709",
+        "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],
     "fake_trc": "bt709",
     "audio_pass": ["-c:a", "aac"],

--- a/video_formats/webm.json
+++ b/video_formats/webm.json
@@ -5,7 +5,8 @@
         "-pix_fmt", ["pix_fmt",["yuv420p","yuva420p"]],
         "-crf", ["crf","INT", {"default": 20, "min": 0, "max": 100, "step": 1}],
         "-b:v", "0",
-        "-vf", "scale=out_color_matrix=bt709"
+        "-vf", "scale=out_color_matrix=bt709",
+        "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],
     "fake_trc": "bt709",
     "audio_pass": ["-c:a", "libvorbis"],


### PR DESCRIPTION
I found an FFmpeg v4.2.1 build and did some testing with it. It seems to do the actual automatic conversions as expected, but it will not save any color space metadata in the output file unless we explicitly ask it. Bit of a bummer that we have to tell it this information even though it already knows it, but it's a negligible price to pay for backwards compatibility.

This PR specifies all the color space metadata for video output. Note that the color range is not specified for ProRes on purpose, as that metadata doesn't seem to be saved no matter what, even with the latest FFmpeg. ProRes needs a deeper look in general, but that's for another day.