### PR TITLE
Use appropriate pixel format and metadata with ProRes.

### DIFF
--- a/video_formats/ProRes.json
+++ b/video_formats/ProRes.json
@@ -1,9 +1,10 @@
 {
+	"name": "ProRes",
     "main_pass":
     [
         "-n", "-c:v", "prores_ks",
-        "-profile:v", ["profile",["1","2","3","4"], {"default": "3"}],
-        "-vf", "scale=out_color_matrix=bt709",
+        "-profile:v", ["profile", ["lt", "standard", "hq", "4444", "4444xq"], {"default": "hq"}],
+        "-vf", "scale=out_color_matrix=bt709,setparams=colorspace=bt709",
         "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],
     "fake_trc": "bt709",

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -464,6 +464,17 @@ class VideoCombine:
                     "-s", f"{dimensions[0]}x{dimensions[1]}", "-r", str(frame_rate), "-i", "-"] \
                     + loop_args
 
+            if video_format.get("name") == "ProRes":
+                o_pix_fmt = "yuv422p10le"
+                profile_idx = video_format["main_pass"].index("-profile:v")
+                profile = video_format["main_pass"][profile_idx+1]
+                if profile in ("4", "4444", "5", "4444xq"):
+                    if has_alpha:
+                        o_pix_fmt = "yuva444p10le"
+                    else:
+                        o_pix_fmt = "yuv444p10le"
+                args += ["-pix_fmt", o_pix_fmt]
+
             images = map(lambda x: x.tobytes(), images)
             env=os.environ.copy()
             if  "environment" in video_format:


### PR DESCRIPTION
FFmpeg was always defaulting to either `yuv444p10le` or `yuva444p10le` for the ProRes output based on alpha presence. However only the 4444 and 4444XQ profiles are supposed to have 444 data. [The others need to be `yuv422p10le`](https://www.apple.com/final-cut-pro/docs/Apple_ProRes.pdf).

This PR makes the output `-pix_fmt` dynamic based on the profile and alpha presence.

---

FFmpeg 4.2 has a weird bug where the output colorspace metadata is determined by the input colorspace, ignoring any conversions or explicit output metadata options. Which is to say, even though the output is a YUV bitstream, the .mov metadata will claim it is RGB because our input was tagged as such. It seems to only happen with the `ProRes.mov` combo, as `libx264.mov` and `libx264.mp4` both receive the correct colorspace metadata.

Luckily there is a reasonable solution, which this PR applies. We can use the `setparams` filter to manually set the colorspace info. This solves the issue and doesn't cause issues with newer FFmpeg either.

---

I changed the ProRes profile options from numbers (`1`, `2`, `3`, `4`) to names (`lt`, `standard`, `hq`, `4444`) as these are friendlier to humans and more closely match how Apple references these. I also added an even higher quality profile - `4444xq`.

I tested and this change shouldn't cause any issues for existing workflows. If a previous numeric profile is still selected, it will continue to work, including with the new dynamic `pix_fmt` code.

---

Also, slight update on the color range metadata situation that I mentioned in #449. Turns out that the .mov container just doesn't support such metadata, so that's unfortunate. In practice most ProRes files are in limited range (as is most video in general) and some prominent applications like Adobe Premiere / Adobe After Effects expect it to be in limited range, so that's what we're going with.

Speaking of After Effects, I also confirmed that the alpha actually works with these latest changes.

![ae](https://github.com/user-attachments/assets/047457d3-022e-4f0e-8fd9-4e1e19c2bffa)
