### PR TITLE
Fix `pre_pass` and `inputs_main_pass` `args` index.

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -478,7 +478,8 @@ class VideoCombine:
                     raise Exception("Formats which require a pre_pass are incompatible with Batch Manager.")
                 images = [b''.join(images)]
                 os.makedirs(folder_paths.get_temp_directory(), exist_ok=True)
-                pre_pass_args = args[:13] + video_format['pre_pass']
+                in_args_len = args.index("-i") + 2 # The index after ["-i", "-"]
+                pre_pass_args = args[:in_args_len] + video_format['pre_pass']
                 merge_filter_args(pre_pass_args)
                 try:
                     subprocess.run(pre_pass_args, input=images[0], env=env,
@@ -487,7 +488,8 @@ class VideoCombine:
                     raise Exception("An error occurred in the ffmpeg prepass:\n" \
                             + e.stderr.decode(*ENCODE_ARGS))
             if "inputs_main_pass" in video_format:
-                args = args[:13] + video_format['inputs_main_pass'] + args[13:]
+                in_args_len = args.index("-i") + 2 # The index after ["-i", "-"]
+                args = args[:in_args_len] + video_format['inputs_main_pass'] + args[in_args_len:]
 
             if output_process is None:
                 if 'gifski_pass' in video_format:


### PR DESCRIPTION
Both `pre_pass` and `inputs_main_pass` had hardcoded `args` indexes, which are no longer valid as the `args` structure has changed.

Neither of these passes are currently being used, so there's no active bug. However, if these were to be used again in the future, they would fail.

This PR resolves the issue by making the index access dynamic based on the `-i -` existence assumption, which should be fairly stable moving forward.