### PR TITLE
Add NVENC AV1 format.

### DIFF
--- a/video_formats/nvenc_av1-mp4.json
+++ b/video_formats/nvenc_av1-mp4.json
@@ -1,0 +1,15 @@
+{
+    "main_pass":
+    [
+        "-n", "-c:v", "av1_nvenc",
+        "-pix_fmt", ["pix_fmt", ["yuv420p", "p010le"]],
+        "-vf", "scale=out_color_matrix=bt709",
+        "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
+    ],
+    "fake_trc": "bt709",
+    "audio_pass": ["-c:a", "aac"],
+    "bitrate": ["bitrate","INT", {"default": 10, "min": 1, "max": 999, "step": 1 }],
+    "megabit": ["megabit","BOOLEAN", {"default": true}],
+    "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],
+    "extension": "mp4"
+}


### PR DESCRIPTION
This is very similar to the other NVENC formats in terms of the JSON.

This format is not supported on FFmpeg 4.2 as it was added in FFmpeg 6.0. However, the NVENC formats are already a bit picky in terms of requirements. In that they require a Nvidia GPU to begin with, and then there's stuff like the 10bit H.264 NVENC option which only works on the Blackwell (RTX 5000) series. So having another NVENC option which won't work with all setups isn't unusual.

Also, we'll hopefully be able to bump the `imageio-ffmpeg` version requirement in the future that will at least remove the FFmpeg version based issue. Meanwhile, others who already have a newer version of `imageio-ffmpeg` installed can use the NVENC AV1 encoder.