### PR TITLE
Use correct `p010le` pixel format with NVENC.

### DIFF
--- a/video_formats/nvenc_h264-mp4.json
+++ b/video_formats/nvenc_h264-mp4.json
@@ -2,7 +2,7 @@
     "main_pass":
     [
         "-n", "-c:v", "h264_nvenc",
-        "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le"]],
+        "-pix_fmt", ["pix_fmt", ["yuv420p", "p010le"]],
         "-vf", "scale=out_color_matrix=bt709",
         "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],

--- a/video_formats/nvenc_hevc-mp4.json
+++ b/video_formats/nvenc_hevc-mp4.json
@@ -3,7 +3,7 @@
     [
         "-n", "-c:v", "hevc_nvenc",
         "-vtag", "hvc1",
-        "-pix_fmt", ["pix_fmt", ["yuv420p", "yuv420p10le"]],
+        "-pix_fmt", ["pix_fmt", ["yuv420p", "p010le"]],
         "-vf", "scale=out_color_matrix=bt709",
         "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],


### PR DESCRIPTION
The NVENC encoders don't support `yuv420p10le`. It still worked because FFmpeg is nice enough to auto-correct it:

```
Incompatible pixel format 'yuv420p10le' for codec 'h264_nvenc', auto-selecting format 'p010le'
Incompatible pixel format 'yuv420p10le' for codec 'hevc_nvenc', auto-selecting format 'p010le'
```

This PR adjusts the format definitions so that we immediately use the correct pixel format.

This change is backwards compatible. People who have selected `yuv420p10le` will see their existing workflows continue working via the auto-correction. However newly chosen options will show the correct format in the UI.