### PR TITLE
Remove deprecated litegraph param

### DIFF
--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -441,7 +441,7 @@ function processDraggedItems(e) {
 }
 function allowDragFromWidget(widget) {
     widget.onPointerDown = function(pointer, node) {
-        pointer.onDragStart = (pointer) => startDraggingItems(node, pointer)
+        pointer.onDragStart = () => startDraggingItems(node, pointer)
         pointer.onDragEnd = processDraggedItems
         app.canvas.dirty_canvas = true
         return true


### PR DESCRIPTION
Unnecessary parameter will be removed in a future release, and brought inline with all other `CanvasPointer` callbacks.