### PR TITLE
VHS.core.js - disable meta png by default

### DIFF
--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1773,7 +1773,7 @@ app.registerExtension({
         category: ['🎥🅥🅗🅢', 'Output', 'MetadataImage'],
         name: 'Save png of first frame for metadata',
         type: 'boolean',
-        defaultValue: true,
+        defaultValue: false,
       },
       {
         id: 'VHS.KeepIntermediate',


### PR DESCRIPTION
Mostly a QoL suggestion to eliminate extra file cleanup for regular users.  I couldn't find how to remove this in a fresh install's user settings or I would have just configured it that way.  I'd prefer default metadata png generation be disabled by default because comfy podman containers are re-provisioned each session to help keep Comfy & all extensions up to date automatically.  This means only the extensions/workflows/nodes are preserved, not the overarching ComfyUI user settings like where this setting exists.  Defaulting to true means each new sesh requires manually disabling that setting or deleting an extra file for each prompt output they don't like.  I notice you also default to true in nodes.py unless this proposed setting is defined one way or another.  

If you would prefer keeping this setting as true for new installs, would you advise how I can disable programmatically, the syntax for settings maybe?  Or maybe this setting could migrate into the workflow's "Video Combine" node settings themselves?  That node already has a save_metadata option but likely only impacts the vid file output, not this global png setting.