### PR TITLE
add ffv1 support

### DIFF
--- a/video_formats/ffv1-mkv.json
+++ b/video_formats/ffv1-mkv.json
@@ -1,0 +1,17 @@
+{
+    "main_pass": [
+        "-n",
+        "-c:v", "ffv1",
+        "-level", ["level", ["0", "1", "3"], {"default": "3"}],
+        "-coder", ["coder", ["0", "1", "2"], {"default": "1"}],
+        "-context", ["context", ["0", "1"], {"default": "1"}],
+        "-g", ["gop_size", "INT", {"default": 1, "min": 1, "max": 300, "step": 1}],
+        "-slices", ["slices", ["4", "6", "9", "12", "16", "20", "24", "30"], {"default": "16"}],
+        "-slicecrc", ["slicecrc", ["0", "1"], {"default": "1"}],
+        "-pix_fmt", ["pix_fmt", ["bgra", "rgba64le", "yuv420p", "yuv422p", "yuv444p", "yuva420p", "yuva422p", "yuva444p", "yuv420p10le", "yuv422p10le", "yuv444p10le", "yuv420p12le", "yuv422p12le", "yuv444p12le", "yuv420p14le", "yuv422p14le", "yuv444p14le", "yuv420p16le", "yuv422p16le", "yuv444p16le", "gray", "gray10le", "gray12le", "gray16le"], {"default": "bgra"}]
+    ],
+    "audio_pass": ["-c:a", "flac"],
+    "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],
+    "trim_to_audio": ["trim_to_audio", "BOOLEAN", {"default": false}],
+    "extension": "mkv"
+}

--- a/web/js/videoinfo.js
+++ b/web/js/videoinfo.js
@@ -11,7 +11,7 @@ function getVideoMetadata(file) {
             let decoder = new TextDecoder();
             // Check for known valid magic strings
             if (dataView.getUint32(0) == 0x1A45DFA3) {
-                //webm
+                //webm/mkv (both use EBML/Matroska format)
                 //see http://wiki.webmproject.org/webm-metadata/global-metadata
                 //and https://www.matroska.org/technical/elements.html
                 //contrary to specs, tag seems consistently at start
@@ -76,6 +76,9 @@ function isVideoFile(file) {
     if (file?.name?.endsWith(".mp4")) {
         return true;
     }
+    if (file?.name?.endsWith(".mkv")) {
+        return true;
+    }
 
     return false;
 }
@@ -83,8 +86,8 @@ function isVideoFile(file) {
 let originalHandleFile = app.handleFile;
 app.handleFile = handleFile;
 let fileInput = document.getElementById("comfy-file-input")
-//hijack comfy-file-input to allow webm/mp4
-fileInput.accept += ",video/webm,video/mp4";
+//hijack comfy-file-input to allow webm/mp4/mkv
+fileInput.accept += ",video/webm,video/mp4,video/x-matroska";
 
 async function handleFile(file) {
     if (file?.type?.startsWith("video/") || isVideoFile(file)) {


### PR DESCRIPTION
FFV1 is a nice lossless format that allows recovering the original images for postprocessing, but it still offers reasonable compression levels. It is nowadays specified for MP4 containers as well, but ffmpeg support was only added in nov '24: https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/0b8c9cf5b490a0231949ab3c6d797462ae001730 which is a bit too new, so for now MKV is enough.

The issue with lossless animated webp is that there is basically no player support (due to no ffmpeg support!) except for browsers, so going for something that is much older and well established is easier.