### PR TITLE
Support Animated latent previews on subgraph nodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-videohelpersuite"
 description = "Nodes related to video workflows"
-version = "1.7.5"
+version = "1.7.6"
 license = { file = "LICENSE" }
 dependencies = ["opencv-python", "imageio-ffmpeg"]
 


### PR DESCRIPTION
Code gets a little messy, but this should handle also handle a hypothetical future with animated previews for concurrent execution, while still properly cleaning up after itself once a workflow ceases execution.

Swapping workflows still causes previews to cease display. I don't know a clean solution for this.