### PR TITLE
Fix frame rate setting not passed to gifski.

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -190,13 +190,14 @@ def ffmpeg_process(args, video_format, video_metadata, file_path, env):
     if len(res) > 0:
         print(res.decode(*ENCODE_ARGS), end="", file=sys.stderr)
 
-def gifski_process(args, dimensions, video_format, file_path, env):
+def gifski_process(args, dimensions, frame_rate, video_format, file_path, env):
     frame_data = yield
     with subprocess.Popen(args + video_format['main_pass'] + ['-f', 'yuv4mpegpipe', '-'],
                           stderr=subprocess.PIPE, stdin=subprocess.PIPE,
                           stdout=subprocess.PIPE, env=env) as procff:
         with subprocess.Popen([gifski_path] + video_format['gifski_pass']
                               + ['-W', f'{dimensions[0]}', '-H', f'{dimensions[1]}']
+                              + ['-r', f'{frame_rate}']
                               + ['-q', '-o', file_path, '-'], stderr=subprocess.PIPE,
                               stdin=procff.stdout, stdout=subprocess.PIPE,
                               env=env) as procgs:
@@ -523,7 +524,7 @@ class VideoCombine:
             if output_process is None:
                 if 'gifski_pass' in video_format:
                     format = 'image/gif'
-                    output_process = gifski_process(args, dimensions, video_format, file_path, env)
+                    output_process = gifski_process(args, dimensions, frame_rate, video_format, file_path, env)
                     audio = None
                 else:
                     args += video_format['main_pass'] + bitrate_arg


### PR DESCRIPTION
Currently, the frame rate parameter `frame_rate` is not passed to the gifski command, so gifski CLI executable will set it to default value 20. This PR fixed it by passing it to `-r` as documented (by running `gifski --help`):

```
Options:
  -r, --fps <num>
          Frame rate of animation. If using PNG files as input, this means the speed, as all frames are kept.
          If video is used, it will be resampled to this constant rate by dropping and/or duplicating frames

          [default: 20]
```