### PR TITLE
Handle potential undefined displayValue in VHS.core.js

### DIFF
--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1643,7 +1643,7 @@ function drawAnnotated(ctx, node, widget_width, y, H) {
       ctx.fill()
     }
     let freeWidth = widget_width - (40 + margin * 2 + 20)
-    let [valueText, valueWidth] = fitText(ctx, this.displayValue(), freeWidth)
+    let [valueText, valueWidth] = fitText(ctx, (this.displayValue?.() ?? ""), freeWidth)
     freeWidth -= valueWidth
 
     ctx.textAlign = 'left'


### PR DESCRIPTION
This fixes an annoying corner-case that seems to catch me a lot.  Possibly related to having multiple identical workflows loaded and subgraphs.  Unfortunately it kills all rendering and forces a page reload.  Fortunately, the fix is very simple.

```
Uncaught TypeError: this.displayValue is not a function
    at LegacyWidget.drawAnnotated [as draw] (VHS.core.js:1646:53)

Called from index.js:

  drawWidgets(ctx, { lowQuality = false, editorAlpha = 1 }) {
    if (!this.widgets) return;
    const nodeWidth = this.size[0];
    const { widgets: widgets2 } = this;
    const H2 = LiteGraph.NODE_WIDGET_HEIGHT;
    const showText = !lowQuality;
    ctx.save();
    ctx.globalAlpha = editorAlpha;
    for (const widget of widgets2) {
      if (!this.isWidgetVisible(widget)) continue;
      const { y: y2 } = widget;
      const outlineColour = widget.advanced ? LiteGraph.WIDGET_ADVANCED_OUTLINE_COLOR : LiteGraph.WIDGET_OUTLINE_COLOR;
      widget.last_y = y2;
      widget.computedDisabled = widget.disabled || this.getSlotFromWidget(widget)?.link != null;
      ctx.strokeStyle = outlineColour;
      ctx.fillStyle = "#222";
      ctx.textAlign = "left";
      if (widget.computedDisabled) ctx.globalAlpha *= 0.5;
      const width2 = widget.width || nodeWidth;
      if (typeof widget.draw === "function") {
        widget.draw(ctx, this, width2, y2, H2, lowQuality); // <-- called from here
      } else {
        toConcreteWidget(widget, this, false)?.drawWidget(ctx, {
          width: width2,
          showText
        });
      }
      ctx.globalAlpha = editorAlpha;
    }
    ctx.restore();
  }
```