### PR TITLE
Workaround for a video with rotation tag

### DIFF
--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -170,7 +170,7 @@ def cv_frame_generator(video, force_rate, frame_load_cap, skip_first_frames,
 def ffmpeg_frame_generator(video, force_rate, frame_load_cap, start_time,
                            custom_width, custom_height, downscale_ratio=8,
                            meta_batch=None, unique_id=None):
-    args_input = ["-i", video]
+    args_input = ["-noautorotate", "-i", video]
     args_dummy = [ffmpeg_path] + args_input +['-c', 'copy', '-frames:v', '1', "-f", "null", "-"]
     size_base = None
     fps_base = None


### PR DESCRIPTION
Ignore the rotation tag in input video. Proper fix would be to respect the tag and rotate a raw frames, but who cares about those rare cases