### PR TITLE
Replace opencv-python with opencv-python-headless

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-opencv-python
+opencv-python-headless
 imageio-ffmpeg


### PR DESCRIPTION
Since the nodes don't call GUI functions like `cv2.imshow`, we can use the headless Python package, which also prevents dependency issues when run in containers.