### PR TITLE
fix vueNodes/node 2.0 display issue

### DIFF
--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1610,7 +1610,8 @@ function inner_value_change(widget, value, node, pos) {
 }
 function drawAnnotated(ctx, node, widget_width, y, H) {
   const litegraph_base = LiteGraph
-  const show_text = app.canvas.ds.scale >= (app.canvas.low_quality_zoom_threshold ?? 0.5)
+  // In vueNodes mode, always show text since Vue renders at 1:1 scale
+  const show_text = LiteGraph.vueNodesMode || app.canvas.ds.scale >= (app.canvas.low_quality_zoom_threshold ?? 0.5)
   const margin = 15
   ctx.strokeStyle = litegraph_base.WIDGET_OUTLINE_COLOR
   ctx.fillStyle = litegraph_base.WIDGET_BGCOLOR


### PR DESCRIPTION
hi,
just fix widget display issue in vueNodes mode.

before
<img width="881" height="700" alt="image" src="https://github.com/user-attachments/assets/b66fd750-f0ed-4e5e-a516-69afee1d8bf5" />

after
<img width="1238" height="965" alt="image" src="https://github.com/user-attachments/assets/22066b8c-3e14-47b1-9196-142afa15beb0" />

another fix sent in frontend https://github.com/Comfy-Org/ComfyUI_frontend/pull/7925
