### PR TITLE
add canvasOnly for audiopreview

### DIFF
--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -845,6 +845,7 @@ function addAudioPreview(nodeType, isInput=true) {
         var previewWidget = this.addDOMWidget("audiopreview", "preview", element, {
             serialize: false,
             hideOnZoom: true,
+            canvasOnly: true,
             getValue() {
                 return element.value;
             },


### PR DESCRIPTION
add canvasOnly for audiopreview, we will use native widget in Node 2.0

Litegraph
<img width="676" height="664" alt="image" src="https://github.com/user-attachments/assets/5aaae549-772d-4d95-8698-b2fa743029e7" />

Node 2.0
<img width="705" height="715" alt="image" src="https://github.com/user-attachments/assets/ca7c243e-2810-4892-ba6d-46d3b505fd04" />
