### PR TITLE
Fix: preserve workflow metadata when audio is muxed into video

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -595,7 +595,9 @@ class VideoCombine:
                     apad = ["-af", "apad=whole_dur="+str(min_audio_dur)]
                 mux_args = [ffmpeg_path, "-v", "error", "-n", "-i", file_path,
                             "-ar", str(audio['sample_rate']), "-ac", str(channels),
-                            "-f", "f32le", "-i", "-", "-c:v", "copy"] \
+                            "-f", "f32le", "-i", "-", "-c:v", "copy",
+                            "-map_metadata", "0",
+                            "-movflags", "use_metadata_tags"] \
                             + video_format["audio_pass"] \
                             + apad + ["-shortest", output_file_with_audio_path]
 


### PR DESCRIPTION
## Summary
 - Since c67ff3e, metadata is written as custom ffmpeg keys (`prompt`, `workflow`) using `-movflags use_metadata_tags` instead of a single standard `comment` field                          
 - The audio mux step remuxes the video-only file with audio, but ffmpeg only auto-copies standard metadata fields - custom keys were silently dropped
  - Added `-map_metadata 0` and `-movflags use_metadata_tags` to `mux_args` so custom metadata survives the remux 