### PR TITLE
Fix audio preview sizing in vueNodes mode

### DIFF
--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -846,6 +846,8 @@ function addAudioPreview(nodeType, isInput=true) {
     chainCallback(nodeType.prototype, "onNodeCreated", function() {
         var element = document.createElement("audio");
         element.controls = true
+        element.style['width'] = "100%"
+        element.style['minHeight'] = "50px"
         const previewNode = this;
         var previewWidget = this.addDOMWidget("audiopreview", "preview", element, {
             serialize: false,


### PR DESCRIPTION
- Add width: 100% so audio player resizes with node width
- Add minHeight: 50px to prevent audio preview from being squeezed to zero height, matching the computeSize return value

before
https://github.com/user-attachments/assets/55ca2d8a-24d0-48ac-85b1-9c3056740566

after
https://github.com/user-attachments/assets/fb23750e-933d-4186-be38-9f40abf489ff

