### PR TITLE
 Add filename to video_info and VideoInfo nodes 

### DIFF
--- a/videohelpersuite/load_video_nodes.py
+++ b/videohelpersuite/load_video_nodes.py
@@ -412,6 +412,7 @@ def load_video(meta_batch=None, unique_id=None, memory_limit_mb=None, vae=None,
         "loaded_duration": len(images) * target_frame_time,
         "loaded_width": new_width,
         "loaded_height": new_height,
+        "filename": os.path.splitext(os.path.basename(kwargs['video']))[0],
     }
     if vae is None:
         return (images, len(images), audio, video_info)

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -887,7 +887,7 @@ class VideoInfo:
 
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
 
-    RETURN_TYPES = ("FLOAT","INT", "FLOAT", "INT", "INT", "FLOAT","INT", "FLOAT", "INT", "INT")
+    RETURN_TYPES = ("FLOAT","INT", "FLOAT", "INT", "INT", "FLOAT","INT", "FLOAT", "INT", "INT", "STRING")
     RETURN_NAMES = (
         "source_fps🟨",
         "source_frame_count🟨",
@@ -899,6 +899,7 @@ class VideoInfo:
         "loaded_duration🟦",
         "loaded_width🟦",
         "loaded_height🟦",
+        "filename",
     )
     FUNCTION = "get_video_info"
 
@@ -912,7 +913,7 @@ class VideoInfo:
             source_info.append(video_info[f"source_{key}"])
             loaded_info.append(video_info[f"loaded_{key}"])
 
-        return (*source_info, *loaded_info)
+        return (*source_info, *loaded_info, video_info.get("filename", ""))
 
 
 class VideoInfoSource:
@@ -926,13 +927,14 @@ class VideoInfoSource:
 
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
 
-    RETURN_TYPES = ("FLOAT","INT", "FLOAT", "INT", "INT",)
+    RETURN_TYPES = ("FLOAT","INT", "FLOAT", "INT", "INT", "STRING")
     RETURN_NAMES = (
         "fps🟨",
         "frame_count🟨",
         "duration🟨",
         "width🟨",
         "height🟨",
+        "filename",
     )
     FUNCTION = "get_video_info"
 
@@ -944,7 +946,7 @@ class VideoInfoSource:
         for key in keys:
             source_info.append(video_info[f"source_{key}"])
 
-        return (*source_info,)
+        return (*source_info, video_info.get("filename", ""))
 
 
 class VideoInfoLoaded:
@@ -958,13 +960,14 @@ class VideoInfoLoaded:
 
     CATEGORY = "Video Helper Suite 🎥🅥🅗🅢"
 
-    RETURN_TYPES = ("FLOAT","INT", "FLOAT", "INT", "INT",)
+    RETURN_TYPES = ("FLOAT","INT", "FLOAT", "INT", "INT", "STRING")
     RETURN_NAMES = (
         "fps🟦",
         "frame_count🟦",
         "duration🟦",
         "width🟦",
         "height🟦",
+        "filename",
     )
     FUNCTION = "get_video_info"
 
@@ -976,7 +979,7 @@ class VideoInfoLoaded:
         for key in keys:
             loaded_info.append(video_info[f"loaded_{key}"])
 
-        return (*loaded_info,)
+        return (*loaded_info, video_info.get("filename", ""))
 
 class SelectFilename:
     @classmethod


### PR DESCRIPTION
## Summary

- Add `filename` (without path and extension) to the `VHS_VIDEOINFO` dict in `load_video()`
- Expose `filename` as a `STRING` output on all three VideoInfo nodes: `Video Info`, `Video Info (Source)`, and `Video Info (Loaded)`

This makes it easy to use the source video's filename in downstream nodes (e.g. for naming outputs).
