### PR TITLE
fix: route Save preview/workflow downloads through ComfyUI frontend helper

### DIFF
--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1117,6 +1117,23 @@ function addVideoPreview(nodeType, isInput=true) {
     });
 }
 let copiedPath = undefined
+function downloadUrl(url, filename) {
+    // Prefer the ComfyUI frontend's built-in download helper when available.
+    // It transparently handles cross-origin redirects (e.g. cloud GCS signed URLs),
+    // which otherwise cause Chrome to drop the `download` attribute and navigate
+    // the current tab - triggering a "Leave site?" prompt instead of a download.
+    const platformDownload = window.app?.extensionManager?.downloadFile;
+    if (typeof platformDownload === "function") {
+        platformDownload(url, filename);
+        return;
+    }
+    const a = document.createElement("a");
+    a.href = url;
+    a.setAttribute("download", filename);
+    document.body.append(a);
+    a.click();
+    requestAnimationFrame(() => a.remove());
+}
 function addPreviewOptions(nodeType) {
     chainCallback(nodeType.prototype, "getExtraMenuOptions", function(_, options) {
         // The intended way of appending options is returning a list of extra options,
@@ -1154,12 +1171,7 @@ function addPreviewOptions(nodeType) {
                 {
                     content: "Save preview",
                     callback: () => {
-                        const a = document.createElement("a");
-                        a.href = url;
-                        a.setAttribute("download", previewWidget.value.params.filename);
-                        document.body.append(a);
-                        a.click();
-                        requestAnimationFrame(() => a.remove());
+                        downloadUrl(url, previewWidget.value.params.filename);
                     },
                 }
             );
@@ -1183,12 +1195,7 @@ function addPreviewOptions(nodeType) {
                 optNew.push({
                     content: "Save workflow image",
                     callback: () => {
-                        const a = document.createElement("a");
-                        a.href = wUrl;
-                        a.setAttribute("download", previewWidget.value.params.workflow);
-                        document.body.append(a);
-                        a.click();
-                        requestAnimationFrame(() => a.remove());
+                        downloadUrl(wUrl, previewWidget.value.params.workflow);
                     }
                 });
             }


### PR DESCRIPTION
## Problem

Right-clicking a Load Video (VHS) node and selecting **Save preview** on ComfyUI cloud shows Chrome's "Leave site?" popup. Clicking "Leave" then completes the download.

Root cause:
- VHS's `Save preview` callback creates an `<a href=... download=...>` and clicks it.
- On cloud, `/api/view` responds with a **302 redirect to `storage.googleapis.com`** (GCS signed URL).
- Per Chrome's cross-origin download rule (Chrome ≥85), the `download` attribute is **silently dropped** whenever the final response origin differs from the initiator — including via redirect.
- The anchor then degrades to a top-level navigation on the current tab. Because ComfyUI has a `beforeunload` listener active when there are modified workflows, Chrome shows the "Leave site?" confirmation. After confirming, the server's `Content-Disposition: attachment` triggers the download as a fallback.

`Save workflow image` (a few lines below) uses the same anchor pattern and has the same bug.

## Fix

Introduce a `downloadUrl` helper that prefers the ComfyUI frontend's public download helper (`window.app.extensionManager.downloadFile`) when the host exposes it. That helper already encapsulates the cloud/local branching on the frontend side (blob-fetch on cloud, native anchor on local/desktop), so VHS doesn't need any cloud awareness of its own.

When the API is not available, we fall back to the existing anchor pattern — so older frontends keep the current behavior with no regression.

Applied to both `Save preview` and `Save workflow image`.

## Behavior matrix

| Environment | Before | After |
|---|---|---|
| Local ComfyUI (same-origin) | download works | download works (fallback path; mechanically identical code) |
| Desktop Electron | download works | download works (same) |
| Cloud + newer frontend that exposes `downloadFile` | "Leave site?" popup bug | fixed (blob-fetch path) |
| Cloud + older frontend | "Leave site?" popup bug | same as before (fallback; no regression) |

No cloud-specific branching inside VHS. All distribution-specific logic stays in the host frontend.

## Dependency

The fix's cloud benefit activates once the ComfyUI frontend exposes `downloadFile` on `app.extensionManager` (separate PR on the ComfyUI_frontend side). This PR is safe to merge before that lands — it just stays on the fallback path until the frontend upgrade reaches users.

## Testing

- Local ComfyUI: Save preview / Save workflow image still download the same file with the same filename as before.
- Chrome DevTools with network throttled: same behavior.
- Cloud (with frontend PR applied): no "Leave site?" popup; file downloads directly.

Draft for review — happy to adjust naming or placement if you have preferences.