### PR TITLE
Fix deprecated widgetInputs.js import with modern API shim

### DIFF
--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1,7 +1,13 @@
 import { app } from '../../../scripts/app.js'
 import { api } from '../../../scripts/api.js'
-import { setWidgetConfig } from '../../../extensions/core/widgetInputs.js'
 import { applyTextReplacements } from "../../../scripts/utils.js";
+// === SHIM FOR NEW COMFYUI (removes widgetInputs.js warning) ===
+let setWidgetConfig;
+if (window?.comfyAPI?.widgetInputs) {
+    ({ setWidgetConfig } = window.comfyAPI.widgetInputs);
+} else {
+    ({ setWidgetConfig } = await import('../../../extensions/core/widgetInputs.js'));
+}
 
 function chainCallback(object, property, callback) {
     if (object == undefined) {


### PR DESCRIPTION
ComfyUI has deprecated direct imports of /extensions/core/widgetInputs.js and now exposes these via window.comfyAPI.widgetInputs. This replaces the static import with a shim that uses the new API when available, falling back to the legacy path for compatibility. Also moves the applyTextReplacements static import above the shim block to maintain valid JS import order.