### PR TITLE
fix(metadata): stop double-stringifying prompt in MP4 metadata

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -352,7 +352,7 @@ class VideoCombine:
         video_metadata = {}
         if prompt is not None:
             metadata.add_text("prompt", json.dumps(prompt))
-            video_metadata["prompt"] = json.dumps(prompt)
+            video_metadata["prompt"] = prompt
         if extra_pnginfo is not None:
             for x in extra_pnginfo:
                 metadata.add_text(x, json.dumps(extra_pnginfo[x]))


### PR DESCRIPTION
`Video Combine` stored `video_metadata["prompt"] = json.dumps(prompt)` while every other field is stored as a raw object. `ffmpeg_process` then runs `json.dumps` on each value, so `prompt` ends up double-encoded in the embedded MP4 metadata.

Match the `extra_pnginfo` branch and store the raw object. The PNG metadata path on line 354 is unchanged.

The original double-wrap was an intentional workaround for JSON's stricter NaN handling (per @AustinMroz). It predates the consumer-facing schema introduced in #627 and is no longer needed.