### PR TITLE
fix(serialize): coerce filename_prefix to string before applyTextReplacements

### DIFF
--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -630,7 +630,7 @@ function addDateFormatting(nodeType, field, timestamp_widget = false) {
     chainCallback(nodeType.prototype, "onNodeCreated", function() {
         const widget = this.widgets.find((w) => w.name === field);
         widget.serializeValue = () => {
-            return applyTextReplacements(app, widget.value);
+            return applyTextReplacements(app, String(widget.value ?? ""));
         };
     });
 }


### PR DESCRIPTION
Fixes #658.

`addDateFormatting` overrides `VHS_VideoCombine`'s `filename_prefix.serializeValue` to run `applyTextReplacements(app, widget.value)` directly. The frontend's `applyTextReplacements` assumes a string and immediately calls `input.replace(...)` ([searchAndReplace.ts:11 in the trace](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/issues/658)), so any non-string widget value blows up the queue with `TypeError: t.replace is not a function`.

Although `filename_prefix` is declared `STRING` in [`nodes.py:257`](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/blob/main/videohelpersuite/nodes.py#L257), in practice the runtime `widget.value` can land as numeric (converted-input scenarios, subgraph remap) or nullish (uninitialized), per @nicholas-eden's reproduction on a Wan2.2 T2V workflow. The pre-fix path then throws inside `serializeValue`, before the prompt is even submitted.

## Fix

Coerce defensively in [`web/js/VHS.core.js:633`](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/blob/main/web/js/VHS.core.js#L633):

```diff
-            return applyTextReplacements(app, widget.value);
+            return applyTextReplacements(app, String(widget.value ?? ""));
```

`String(x ?? "")` makes the normal string path identical, and turns nullish values into `""` (rather than `"null"` / `"undefined"` from a bare `String(x)`).

## Verification

Standalone Node harness (`verify_serialize.js`) stubs `applyTextReplacements` with the real `input.replace(...)` shape and exercises both the pre-fix and post-fix wrappers across 7 inputs.

| Input | Pre-fix | Post-fix |
|---|---|---|
| `"ComfyUI"` | `"ComfyUI"` | `"ComfyUI"` |
| `"\${name}"` (placeholder) | `"<name>"` | `"<name>"` |
| `24` (the bug) | THREW `t.replace is not a function` | `"24"` |
| `true` | THREW | `"true"` |
| `null` | THREW | `""` |
| `undefined` | THREW | `""` |
| `""` | `""` | `""` |

7/7 pass post-fix. The pre-fix `THREW` rows match the exact error in the issue trace.

## Scope notes

- Single callsite. `addDateFormatting` is invoked only at [`VHS.core.js:2058`](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/blob/main/web/js/VHS.core.js#L2058) for `filename_prefix` on `VHS_VideoCombine`.
- `directoryWidget.serializeValue` at L650 doesn't route through `applyTextReplacements`, so it doesn't share this failure mode.
- No new dependencies, no public API change.

Credit @nicholas-eden for the well-traced report — the exact root-cause callout pointed straight at L633.