### PR TITLE
fix(preview): handle 5-D video-TAESD output for Wan2.x animated previews

### DIFF
--- a/videohelpersuite/latent_preview.py
+++ b/videohelpersuite/latent_preview.py
@@ -82,8 +82,14 @@ class WrappedPreviewer(latent_preview.LatentPreviewer):
             ind = (ind + 1) % leng
     def decode_latent_to_preview(self, x0):
         if hasattr(self, 'taesd'):
-            x_sample = self.taesd.decode(x0).movedim(1, 3)
-            return x_sample
+            x_sample = self.taesd.decode(x0)
+            if x_sample.ndim == 5:
+                # Video TAESDs (e.g. lighttaew2_1, lighttaew2_2) return
+                # [B, T, H, W, C] with channels-last; merge the temporal
+                # dim into batch so the downstream interpolate path keeps
+                # a 2-D spatial layout. (#667)
+                return x_sample.reshape(-1, *x_sample.shape[2:])
+            return x_sample.movedim(1, 3)
         else:
             if self.latent_rgb_factors_reshape is not None:
                 x0 = self.latent_rgb_factors_reshape(x0)

--- a/videohelpersuite/latent_preview.py
+++ b/videohelpersuite/latent_preview.py
@@ -84,11 +84,11 @@ class WrappedPreviewer(latent_preview.LatentPreviewer):
         if hasattr(self, 'taesd'):
             x_sample = self.taesd.decode(x0)
             if x_sample.ndim == 5:
-                # Video TAESDs (e.g. lighttaew2_1, lighttaew2_2) return
-                # [B, T, H, W, C] with channels-last; merge the temporal
-                # dim into batch so the downstream interpolate path keeps
-                # a 2-D spatial layout. (#667)
-                return x_sample.reshape(-1, *x_sample.shape[2:])
+                # Video TAESDs return [B, C, T, H, W]. Move channels to the
+                # end and flatten [B, T] into the batch dim so the result is
+                # the [N, H, W, C] shape the downstream interpolate path
+                # already expects. (#667)
+                return x_sample.movedim(1, -1).flatten(0, 1)
             return x_sample.movedim(1, 3)
         else:
             if self.latent_rgb_factors_reshape is not None:

--- a/videohelpersuite/latent_preview.py
+++ b/videohelpersuite/latent_preview.py
@@ -84,10 +84,7 @@ class WrappedPreviewer(latent_preview.LatentPreviewer):
         if hasattr(self, 'taesd'):
             x_sample = self.taesd.decode(x0)
             if x_sample.ndim == 5:
-                # Video TAESDs return [B, C, T, H, W]. Move channels to the
-                # end and flatten [B, T] into the batch dim so the result is
-                # the [N, H, W, C] shape the downstream interpolate path
-                # already expects. (#667)
+                # Video TAESDs return [B, C, T, H, W]; collapse to [N, H, W, C]. (#667)
                 return x_sample.movedim(1, -1).flatten(0, 1)
             return x_sample.movedim(1, 3)
         else:


### PR DESCRIPTION
Fixes #667.

Animated previews on Wan 2.x (and any model with a video TAESD installed) crash mid-sample with:

```
ValueError: Input and output must have the same number of spatial dimensions, but got input with spatial dimensions of [608, 1024, 1] and output size of (304, 512).
```

The traceback in #667 lands at `videohelpersuite/latent_preview.py:64` in `F.interpolate(image_tensor, (height, 512), mode='bilinear')`.

Cause: the video TAESDs (`lighttaew2_1`, `lighttaew2_2`, `taehv`, etc.) return a 5-D tensor `[B, C, T, H, W]` from `taesd.decode(...)`, while image TAESDs return 4-D `[B, C, H, W]`. `WrappedPreviewer.decode_latent_to_preview` only handled the 4-D shape: `movedim(1, 3)` turns `[B, C, H, W]` into `[B, H, W, C]`, but on a 5-D tensor it just shuffles to `[B, T, H, C, W]` and leaves a 5-D tensor flowing into `process_previews`. `F.interpolate` there is set up for 2 spatial dims and fails on the 3 spatial dims of a 5-D input.

Fix: detect the 5-D output, lift channels to the last dim, and flatten `[B, T]` into the batch slot. The result is `[N, H, W, C]` which matches what the 4-D image-TAESD path already produces and what `process_previews` expects.

```diff
 def decode_latent_to_preview(self, x0):
     if hasattr(self, 'taesd'):
-        x_sample = self.taesd.decode(x0).movedim(1, 3)
-        return x_sample
+        x_sample = self.taesd.decode(x0)
+        if x_sample.ndim == 5:
+            return x_sample.movedim(1, -1).flatten(0, 1)
+        return x_sample.movedim(1, 3)
```

Verified on a synthetic 5-D output of TAEHV's shape ([B, C, T, H, W] = [1, 3, 5, 1024, 2048]): the reshape produces [5, 1024, 2048, 3] and the first preview equals frame 0 with the original channel layout (not a single channel stretched over time, which is what an earlier version of this PR was producing). The 4-D image-TAESD path is byte-identical to before. The non-taesd Latent2RGB path is not on this branch.