### PR TITLE
On mp4 audio creation, force copy metadata fields

### DIFF
--- a/video_formats/h264-mp4.json
+++ b/video_formats/h264-mp4.json
@@ -8,7 +8,7 @@
         "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],
     "fake_trc": "bt709",
-    "audio_pass": ["-c:a", "aac"],
+    "audio_pass": ["-c:a", "aac", "-movflags", "use_metadata_tags"],
     "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],
     "trim_to_audio": ["trim_to_audio", "BOOLEAN", {"default": false}],
     "extension": "mp4"

--- a/video_formats/h265-mp4.json
+++ b/video_formats/h265-mp4.json
@@ -11,7 +11,7 @@
         "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],
     "fake_trc": "bt709",
-    "audio_pass": ["-c:a", "aac"],
+    "audio_pass": ["-c:a", "aac", "-movflags", "use_metadata_tags"],
     "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],
     "extension": "mp4"
 }

--- a/video_formats/nvenc_av1-mp4.json
+++ b/video_formats/nvenc_av1-mp4.json
@@ -7,7 +7,7 @@
         "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],
     "fake_trc": "bt709",
-    "audio_pass": ["-c:a", "aac"],
+    "audio_pass": ["-c:a", "aac", "-movflags", "use_metadata_tags"],
     "bitrate": ["bitrate","INT", {"default": 10, "min": 1, "max": 999, "step": 1 }],
     "megabit": ["megabit","BOOLEAN", {"default": true}],
     "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],

--- a/video_formats/nvenc_h264-mp4.json
+++ b/video_formats/nvenc_h264-mp4.json
@@ -7,7 +7,7 @@
         "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],
     "fake_trc": "bt709",
-    "audio_pass": ["-c:a", "aac"],
+    "audio_pass": ["-c:a", "aac", "-movflags", "use_metadata_tags"],
     "bitrate": ["bitrate","INT", {"default": 10, "min": 1, "max": 999, "step": 1 }],
     "megabit": ["megabit","BOOLEAN", {"default": true}],
     "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],

--- a/video_formats/nvenc_hevc-mp4.json
+++ b/video_formats/nvenc_hevc-mp4.json
@@ -8,7 +8,7 @@
         "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],
     "fake_trc": "bt709",
-    "audio_pass": ["-c:a", "aac"],
+    "audio_pass": ["-c:a", "aac", "-movflags", "use_metadata_tags"],
     "bitrate": ["bitrate","INT", {"default": 10, "min": 1, "max": 999, "step": 1 }],
     "megabit": ["megabit","BOOLEAN", {"default": true}],
     "save_metadata": ["save_metadata", "BOOLEAN", {"default": true}],


### PR DESCRIPTION
Since `prompt` and `workflow` are non-standard metadata fields for mp4 files, they require an additional flag during the audio pass to ensure the metadata is copied.

Resolves #649 