### PR TITLE
fix: handle bfloat16 in tensor_to_int (combine video crash)

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -122,7 +122,8 @@ def apply_format_widgets(format_name, kwargs):
     return video_format
 
 def tensor_to_int(tensor, bits):
-    tensor = tensor.cpu().numpy() * (2**bits-1) + 0.5
+    # .float() so bfloat16 survives: numpy has no bfloat16 dtype and would raise
+    tensor = tensor.cpu().float().numpy() * (2**bits-1) + 0.5
     return np.clip(tensor, 0, (2**bits-1))
 def tensor_to_shorts(tensor):
     return tensor_to_int(tensor, 16).astype(np.uint16)


### PR DESCRIPTION
Fixes #685.

### Problem

`tensor_to_int` converts the image tensor with `tensor.cpu().numpy()`, but numpy has no `bfloat16` dtype. When a workflow feeds VideoHelperSuite a `bfloat16` image tensor (e.g. from a bf16 VAE/model), combining the video crashes:

```
File ".../videohelpersuite/nodes.py", line 391, in combine_video
File ".../videohelpersuite/nodes.py", line 130, in tensor_to_bytes
File ".../videohelpersuite/nodes.py", line 125, in tensor_to_int
TypeError: Got unsupported ScalarType BFloat16
```

### Fix

Cast with `.float()` before the numpy conversion. This fixes both the 8-bit (`tensor_to_bytes`) and 16-bit (`tensor_to_shorts`) paths, since both route through `tensor_to_int`.

```python
tensor = tensor.cpu().float().numpy() * (2**bits-1) + 0.5
```

### Verification

Tested against the verbatim function with real `torch` + `numpy`:
- `bfloat16` input: before → the reported `TypeError`; after → correct `uint8`/`uint16` output.
- `float32` output is byte-identical before/after (no regression); `float16` is unaffected.
