### PR TITLE
Sanitize non-finite audio samples before ffmpeg encoding

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -599,8 +599,16 @@ class VideoCombine:
                             + video_format["audio_pass"] \
                             + apad + ["-shortest", output_file_with_audio_path]
 
-                audio_data = audio['waveform'].squeeze(0).transpose(0,1) \
-                        .numpy().tobytes()
+                waveform = audio['waveform'].squeeze(0).transpose(0, 1)
+
+                waveform = torch.nan_to_num(
+                    waveform,
+                    nan=0.0,
+                    posinf=0.0,
+                    neginf=0.0,
+                ).clamp(-1.0, 1.0)
+
+                audio_data = waveform.contiguous().cpu().numpy().astype(np.float32).tobytes()
                 merge_filter_args(mux_args, '-af')
                 try:
                     res = subprocess.run(mux_args, input=audio_data,


### PR DESCRIPTION
LTX audio decoding can occasionally produce NaN or Inf waveform samples. VideoHelperSuite currently forwards these directly to ffmpeg as f32le, causing AAC encoding to fail with:

Input contains (near) NaN/+-Inf
Error submitting audio frame to the encoder

This change replaces non-finite samples with silence, clamps the waveform to [-1.0, 1.0], and explicitly converts it to float32 before passing it to ffmpeg.