### PR TITLE
Move audio waveform to CPU before numpy conversion in mux paths

### DIFF
--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -600,7 +600,7 @@ class VideoCombine:
                             + apad + ["-shortest", output_file_with_audio_path]
 
                 audio_data = audio['waveform'].squeeze(0).transpose(0,1) \
-                        .numpy().tobytes()
+                        .cpu().numpy().tobytes()
                 merge_filter_args(mux_args, '-af')
                 try:
                     res = subprocess.run(mux_args, input=audio_data,
@@ -731,7 +731,7 @@ class AudioToVHSAudio:
                     "-i", "-", "-f", "wav", "-"]
 
         audio_data = audio['waveform'].squeeze(0).transpose(0,1) \
-                .numpy().tobytes()
+                .cpu().numpy().tobytes()
         try:
             res = subprocess.run(mux_args, input=audio_data,
                                  capture_output=True, check=True)


### PR DESCRIPTION
Fixes #702. Also fixes #631, where two users independently arrived at this same one-line change back in January.

`Video Combine`'s two audio muxing paths call `.numpy()` on the waveform without moving it to CPU:

```python
audio_data = audio['waveform'].squeeze(0).transpose(0,1) \
        .numpy().tobytes()
```

When the AUDIO tensor is still on the GPU this raises `TypeError: can't convert cuda:0 device type tensor to numpy`. The frame path at line 125 already does `.cpu().numpy()`, which is why the silent video writes successfully and only the audio branch fails.

That failure order makes it more annoying than it looks: the video file exists and plays with no sound, and the exception aborts the prompt, so any other outputs in the graph are lost too. It reads like a graph problem rather than a device problem.

Core produces audio on device and moves it to host at the point of use: `vae_decode_audio` in `comfy_extras/nodes_audio.py` never leaves the GPU, and `AudioSaveHelper` does `audio["waveform"].cpu()` before writing. This change follows the same convention.

`.cpu()` is a no-op when the tensor is already on the host, so nothing changes for anyone who was not hitting the crash.

**Reproduced on:** ComfyUI 0.33.0 with `--gpu-only`, MiniMax-H3 through `VAEDecodeAudio` into `VHS_VideoCombine`. Without the flag the tensor arrives on CPU already, which is probably why this has survived; #631's reporter hit it on LTXV with the stock audio decode node instead.

**One thing I did not touch:** `batched_vae_encode` in `load_video_nodes.py` has the same shape, `yield from vae.encode(image_batch).numpy()`, and VAE encode returns on device. I have not reproduced a failure there and did not want to widen a fix for something I have not tested, but it looks like the same issue on the video-load path.