### PR TITLE
Fix numeric annotated widget labels in Nodes 2.0

### DIFF
--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -1506,6 +1506,7 @@ function button_action(widget) {
   return 'No Disable'
 }
 function fitText(ctx, text, maxLength) {
+    text = String(text)
     if (maxLength <= 0) {
         return ['', 0]
     }


### PR DESCRIPTION
Nodes 2.0 always renders the annotated widget text at 1:1 scale. VHSINT displayValue returns a number, while fitText calls slice when that value needs truncation. This throws text.slice is not a function and prevents VHS_BatchManager and VHS_LoadVideo from mounting their widgets.

Coerce display values at the fitText boundary so numeric annotations follow the same measurement and truncation path as strings.

Reproduction: create VHS_BatchManager or VHS_LoadVideo with Nodes 2.0 enabled at a width that truncates the integer annotation. The current code throws from fitText; this change returns the truncated text.

Tracked downstream as Comfy-Org/ComfyUI_frontend#15948 and FE-1869.