### PR TITLE
Add fallback value for step

### DIFF
--- a/web/js/VHS.core.js
+++ b/web/js/VHS.core.js
@@ -2220,7 +2220,7 @@ app.registerExtension({
                         if (v == 0) {
                             return
                         }
-                        const s = this.options.step
+                        const s = this.options.step ?? 1
                         let sh = this.options.mod ?? 0
                         this.value = Math.round((v - sh) / s) * s + sh
                     },


### PR DESCRIPTION
Under some circumstances likely related to the frontend ECS refactor, step will fail to be assigned. This will likely get fixed as a frontend bug, but there's no cost to applying a patch on the VHS side