### PR TITLE
Handle missing audio streams in video loading

### DIFF
--- a/testframework/server.py
+++ b/testframework/server.py
@@ -22,9 +22,9 @@ async def test(request):
                              capture_output=True, check=True).stdout)['streams'][0]
         aprobe = json.loads(subprocess.run(base_args + ['-select_streams', 'a:0', video],
                              capture_output=True, check=True).stdout)['streams']
-        probe = {'video': vprobe}
+        probe = {'video': vprobe, 'audio': {'stream_count': len(aprobe)}}
         if len(aprobe) > 0:
-            probe['audio'] = aprobe[0]
+            probe['audio'].update(aprobe[0])
         errors = []
         compare = None
         for test in req_data['tests']:

--- a/tests/no-audio.json
+++ b/tests/no-audio.json
@@ -1,0 +1,161 @@
+{
+  "last_node_id": 2,
+  "last_link_id": 2,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "VHS_LoadVideoFFmpeg",
+      "pos": [
+        40,
+        100
+      ],
+      "size": [
+        313,
+        421
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1
+          ]
+        },
+        {
+          "name": "mask",
+          "type": "MASK",
+          "links": null
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": [
+            2
+          ]
+        },
+        {
+          "name": "video_info",
+          "type": "VHS_VIDEOINFO",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_LoadVideoFFmpeg"
+      },
+      "widgets_values": {
+        "video": "no_audio.mp4",
+        "force_rate": 8,
+        "custom_width": 0,
+        "custom_height": 0,
+        "frame_load_cap": 0,
+        "start_time": 0,
+        "format": "None",
+        "videopreview": {
+          "hidden": false,
+          "paused": true,
+          "params": {}
+        }
+      }
+    },
+    {
+      "id": 2,
+      "type": "VHS_VideoCombine",
+      "pos": [
+        500,
+        100
+      ],
+      "size": [
+        220,
+        334
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": 2
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine"
+      },
+      "widgets_values": {
+        "frame_rate": 8,
+        "loop_count": 0,
+        "filename_prefix": "VHS_no_audio",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 19,
+        "save_metadata": false,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": false,
+        "videopreview": {
+          "hidden": false,
+          "paused": false,
+          "params": {}
+        }
+      }
+    }
+  ],
+  "links": [
+    [
+      1,
+      1,
+      0,
+      2,
+      0,
+      "IMAGE"
+    ],
+    [
+      2,
+      1,
+      2,
+      2,
+      1,
+      "AUDIO"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4,
+  "tests": {
+    "2": [
+      {
+        "type": "video",
+        "key": "width",
+        "value": 16
+      },
+      {
+        "type": "video",
+        "key": "height",
+        "value": 16
+      },
+      {
+        "type": "audio",
+        "key": "stream_count",
+        "value": 0
+      }
+    ],
+    "length": 1
+  }
+}

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -660,6 +660,8 @@ class LoadAudio:
         #Eagerly fetch the audio since the user must be using it if the
         #node executes, unlike Load Video
         audio = get_audio(audio_file, start_time=seek_seconds, duration=duration)
+        if audio is None:
+            raise Exception(f"No audio stream found in {audio_file}")
         loaded_duration = audio['waveform'].size(2)/audio['sample_rate']
         return (audio, loaded_duration)
 
@@ -701,6 +703,8 @@ class LoadAudioUpload:
             raise Exception("audio_file is not a valid path: " + audio_file)
 
         audio = get_audio(audio_file, start_time, duration)
+        if audio is None:
+            raise Exception(f"No audio stream found in {audio_file}")
         loaded_duration = audio['waveform'].size(2)/audio['sample_rate']
         return (audio, loaded_duration)
 

--- a/videohelpersuite/utils.py
+++ b/videohelpersuite/utils.py
@@ -10,6 +10,7 @@ from typing import Union
 import functools
 import torch
 from torch import Tensor
+import av
 
 import server
 from .logger import logger
@@ -228,6 +229,14 @@ def get_audio(file, start_time=0, duration=0):
     if duration > 0:
         args += ["-t", str(duration)]
     try:
+        with av.open(file) as container:
+            if len(container.streams.audio) == 0:
+                return None
+    except Exception:
+        # Let the FFmpeg extraction below provide the useful error for files
+        # PyAV cannot inspect.
+        pass
+    try:
         #TODO: scan for sample rate and maintain
         res =  subprocess.run(args + ["-f", "f32le", "-"],
                               capture_output=True, check=True)
@@ -255,15 +264,17 @@ class LazyAudioMap(Mapping):
         self._dict=None
     def __getitem__(self, key):
         if self._dict is None:
-            self._dict = get_audio(self.file, self.start_time, self.duration)
+            # Load Video's audio output is optional. Do not fail the whole
+            # workflow when the source contains only video.
+            self._dict = get_audio(self.file, self.start_time, self.duration) or {}
         return self._dict[key]
     def __iter__(self):
         if self._dict is None:
-            self._dict = get_audio(self.file, self.start_time, self.duration)
+            self._dict = get_audio(self.file, self.start_time, self.duration) or {}
         return iter(self._dict)
     def __len__(self):
         if self._dict is None:
-            self._dict = get_audio(self.file, self.start_time, self.duration)
+            self._dict = get_audio(self.file, self.start_time, self.duration) or {}
         return len(self._dict)
 def lazy_get_audio(file, start_time=0, duration=0, **kwargs):
     return LazyAudioMap(file, start_time, duration)


### PR DESCRIPTION
Fixes an issue I'm having when processing a video file without audio.
To reproduce the problem, create a workflow with two nodes:

- Load Video FFmpeg (Upload)
- Video Combine

and connect IMAGE output to images input, audio output to audio input. Upload a video with no audio. Workflow crashes.

possibly related issues:

#153 #258 #615
